### PR TITLE
feat(codespaces): configure secret input for `POSTMAN_API_KEY`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,13 @@
 	"service": "app",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
+	"secrets": {
+		"POSTMAN_API_KEY": {
+			"description": "Your API key from Postman to send emails. Required for OTP logins.",
+			"documentationUrl": "https://guide.postman.gov.sg/api-guide/generate-your-api-key"
+		}
+	},
+
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
@@ -14,7 +21,7 @@
 	"forwardPorts": [3000, 26257, 8080],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm install && sed s/SESSION_SECRET=random_session_secret/SESSION_SECRET=`npx uuid`/ .env.example > .env.development.local && export $(grep DATABASE_URL .env.development.local | xargs) && npm run migrate"
+	"postCreateCommand": "npm install && sed s/SESSION_SECRET=random_session_secret/SESSION_SECRET=`npx uuid`/ .env.example  | sed s/POSTMAN_API_KEY=// > .env.development.local && export $(grep DATABASE_URL .env.development.local | xargs) && npm run migrate"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A technical kit to quickly build new products from
 [Open Government Products](https://open.gov.sg), Singapore.
 
-This README is also viewable as a [webpage](https://opengovsg.github.io/starter-kit-v2).
+This README is also viewable as a [webpage](https://opengovsg.github.io/starter-kit).
 ## Features
 
 - 🧙‍♂️ E2E typesafety with [tRPC](https://trpc.io)
@@ -49,7 +49,7 @@ The deployment needs a few environment variables to be set for it to function. T
 
 #### Deployment
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fopengovsg%2Fstarter-kit-v2%2Ftree%2Fdevelop&env=DATABASE_URL,POSTMAN_API_KEY,SESSION_SECRET)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fopengovsg%2Fstarter-kit%2Ftree%2Fdevelop&env=DATABASE_URL,POSTMAN_API_KEY,SESSION_SECRET)
 
 ## Working on your product
 

--- a/docs/examples/replies.md
+++ b/docs/examples/replies.md
@@ -1,7 +1,7 @@
 # Example Feature: allowing replies on posts
 
 > 🗒️ This feature is already in the application, but here as documentation on how one could approach the problem.
-> If you want to follow along, you can check out the [`examples/no-replies`](https://github.com/opengovsg/starter-kit-v2/tree/examples/no-replies) branch that does not have this feature yet to follow along. Needed changes are marked with `TODO(example)`, or you may see the commit history for the changes needed.
+> If you want to follow along, you can check out the [`examples/no-replies`](https://github.com/opengovsg/starter-kit/tree/examples/no-replies) branch that does not have this feature yet to follow along. Needed changes are marked with `TODO(example)`, or you may see the commit history for the changes needed.
 
 There are usually 3 main parts to adding a feature:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "starter-kit-v2",
+  "name": "starter-kit",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "starter-kit-v2",
+      "name": "starter-kit",
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "starter-kit-v2",
+  "name": "starter-kit",
   "version": "0.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Take advantage of Recommended Secrets[^1] to allow the user to
conveniently input the API key for Postman within the dev container.

Fixes TOOL-30

[^1]: https://github.blog/changelog/2023-04-24-one-click-into-github-codespaces/#recommended-secrets