### PR TITLE
chore(names): standardize what we call this codebase

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres
 {
-	"name": "Starter Kit v2",
+	"name": "Starter Kit",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",

--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,7 @@ R2_BUCKET_NAME=
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
 R2_PUBLIC_HOSTNAME=
+
+# Other settings
+================
+# NEXT_PUBLIC_APP_NAME= # Uncomment to set application name

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Starter Kit v2
+# Starter Kit
 
 A technical kit to quickly build new products from
 [Open Government Products](https://open.gov.sg), Singapore.
 
-This README is also viewable as a [webpage](https://opengovsg.github.io/starter-kit).
+<!-- This README is also viewable as a [webpage](https://opengovsg.github.io/starter-kit). -->
 ## Features
 
 - 🧙‍♂️ E2E typesafety with [tRPC](https://trpc.io)

--- a/playwright/smoke.test.ts
+++ b/playwright/smoke.test.ts
@@ -1,11 +1,12 @@
 import { test, expect } from '@playwright/test'
+import { browserEnv } from '~/browserEnv'
 
 test.setTimeout(35e3)
 
 test('go to /', async ({ page }) => {
   await page.goto('/')
 
-  await page.waitForSelector(`text=OGP Starter Kit`)
+  await page.waitForSelector(`text=${browserEnv.NEXT_PUBLIC_APP_NAME}`)
 })
 
 test('test 404', async ({ page }) => {

--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@
 # previewsExpireAfterDays: 2
 services:
   - type: web
-    name: trpc-starter-app
+    name: starter-kit-app
     env: node
     plan: free
     ## 👇 Specify the plan for the PR deployment:
@@ -18,9 +18,9 @@ services:
     envVars:
       - key: DATABASE_URL
         fromDatabase:
-          name: trpc-starter-db
+          name: starter-kit-db
           property: connectionString
 
 databases:
-  - name: trpc-starter-db
+  - name: starter-kit-db
     plan: free

--- a/src/browserEnv.ts
+++ b/src/browserEnv.ts
@@ -8,6 +8,7 @@ export const coerceBoolean = z
 
 export const browserEnvSchema = z.object({
   NEXT_PUBLIC_ENABLE_STORAGE: coerceBoolean.default('false'),
+  NEXT_PUBLIC_APP_NAME: z.string().default('Starter Kit')
 })
 
 type BrowserEnv = {
@@ -17,6 +18,7 @@ type BrowserEnv = {
 // Must add public env variables here explicitly so NextJS knows to expose them.
 const _browserEnv: BrowserEnv = {
   NEXT_PUBLIC_ENABLE_STORAGE: process.env.NEXT_PUBLIC_ENABLE_STORAGE,
+  NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
 }
 
 const parsedEnv = browserEnvSchema.safeParse(_browserEnv)

--- a/src/pages/sign-in.tsx
+++ b/src/pages/sign-in.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Text } from '@chakra-ui/react'
 
 import { RestrictedGovtMasthead } from '@opengovsg/design-system-react'
+import { browserEnv } from '~/browserEnv'
 import { MiniFooter } from '~/components/Footer/MiniFooter'
 import {
   BackgroundBox,
@@ -12,6 +13,8 @@ import {
   SignInForm,
 } from '~/features/sign-in/components'
 import { withSessionSsr } from '~/lib/withSession'
+
+const title = browserEnv.NEXT_PUBLIC_APP_NAME
 
 const SignIn = () => {
   return (
@@ -29,11 +32,11 @@ const SignIn = () => {
                 textStyle="responsive-heading.heavy-1280"
                 mb="2.5rem"
               >
-                OGP Starter Kit
+                {title}
               </Text>
               <Box display={{ base: 'initial', lg: 'none' }}>
                 <Box mb={{ base: '0.75rem', lg: '1.5rem' }}>
-                  <Text textStyle="h3">OGP Starter Kit</Text>
+                  <Text textStyle="h3">{title}</Text>
                 </Box>
               </Box>
               <SignInForm />

--- a/src/templates/layouts/DefaultLayout.tsx
+++ b/src/templates/layouts/DefaultLayout.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import { ReactNode } from 'react'
+import { browserEnv } from '~/browserEnv'
 
 type DefaultLayoutProps = { children: ReactNode }
 
@@ -7,7 +8,7 @@ export const DefaultLayout = ({ children }: DefaultLayoutProps) => {
   return (
     <>
       <Head>
-        <title>Prisma Starter</title>
+        <title>{browserEnv.NEXT_PUBLIC_APP_NAME}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
 


### PR DESCRIPTION
## Problem

Inconsistent naming

## Solution

Clean up naming so that people know this as Starter Kit

- Consolidate app name to `browserEnv.NEXT_PUBLIC_APP_NAME`
- Allow the user to set the app name via the relevant env var