### PR TITLE
feat(otp): log to console if Postman not enabled

### DIFF
--- a/src/browserEnv.ts
+++ b/src/browserEnv.ts
@@ -8,7 +8,7 @@ export const coerceBoolean = z
 
 export const browserEnvSchema = z.object({
   NEXT_PUBLIC_ENABLE_STORAGE: coerceBoolean.default('false'),
-  NEXT_PUBLIC_APP_NAME: z.string().default('Starter Kit')
+  NEXT_PUBLIC_APP_NAME: z.string().default('Starter Kit'),
 })
 
 type BrowserEnv = {

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -7,9 +7,19 @@ type SendMailParams = {
   subject: string
 }
 
-export const sendMail = async (params: SendMailParams) => {
-  return await wretch('https://api.postman.gov.sg/v1/transactional/email/send')
-    .auth(`Bearer ${env.POSTMAN_API_KEY}`)
-    .post(params)
-    .res()
+export const sendMail = async (params: SendMailParams): Promise<void> => {
+  if (!env.POSTMAN_API_KEY) {
+    console.warn(
+      'POSTMAN_API_KEY missing. Logging the following mail: ',
+      params
+    )
+    return
+  } else {
+    return await wretch(
+      'https://api.postman.gov.sg/v1/transactional/email/send'
+    )
+      .auth(`Bearer ${env.POSTMAN_API_KEY}`)
+      .post(params)
+      .res()
+  }
 }

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -14,7 +14,7 @@ const serverEnvSchema = z
     DATABASE_URL: z.string().url(),
     NODE_ENV: z.enum(['development', 'test', 'production']),
     OTP_EXPIRY: z.coerce.number().positive().optional().default(600),
-    POSTMAN_API_KEY: z.string(),
+    POSTMAN_API_KEY: z.string().optional(),
     SESSION_SECRET: z.string().min(32),
   })
   .merge(browserEnvSchema.merge(withR2Schema))


### PR DESCRIPTION
## Problem and Solution

People may want to use Starter Kit even if they don't have access to Postman, so allow for this by logging mail to console