### PR TITLE
chore(env): specify a long session secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ DATABASE_URL=postgres://root:root@localhost:26257/app
 # Expiry time for OTP in seconds. Default is 600 seconds (10 minutes).
 OTP_EXPIRY=600
 # Secret to hash sessions. Can use https://1password.com/password-generator/ to generate a strong secret.
-SESSION_SECRET=random_session_secret
+SESSION_SECRET=random_session_secret_that_is_at_least_32_characters
 
 # Mail settings
 # =============


### PR DESCRIPTION
Ensure that .env.example contains a long session secret

Fixes TOOL-45