### PR TITLE
fix: deleted user accessing protected routes

### DIFF
--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -42,13 +42,20 @@ const t = initTRPC.context<Context>().create({
  */
 export const router = t.router
 
-const authMiddleware = t.middleware(({ next, ctx }) => {
-  if (
-    !ctx.session?.user ||
-    !prisma.user.findUnique({ where: { id: ctx.session.user.id } })
-  ) {
+const authMiddleware = t.middleware(async ({ next, ctx }) => {
+  if (!ctx.session?.user) {
     throw new TRPCError({ code: 'UNAUTHORIZED' })
   }
+
+  // this code path is needed if a user does not exist in the database as they were deleted, but the session was active before
+  const user = await prisma.user.findUnique({
+    where: { id: ctx.session.user.id },
+  })
+
+  if (user === null) {
+    throw new TRPCError({ code: 'UNAUTHORIZED' })
+  }
+
   return next({
     ctx: {
       session: {

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -53,6 +53,8 @@ const authMiddleware = t.middleware(async ({ next, ctx }) => {
   })
 
   if (user === null) {
+    ctx.session.destroy()
+
     throw new TRPCError({ code: 'UNAUTHORIZED' })
   }
 


### PR DESCRIPTION
## Problem

Users who previously had a valid session, then had their row removed from the db, would still be able to access protected routes.

## Solution

The conditional statement did not attempt to find the user if a session is set in the context.

If no user found:
- destroys session so that frontend gets redirected to the sign-in page
- throw `UNAUTHORIZED` error

**Cons**
- Additional overhead needing to find the user each time a protected route is accessed, but the minor lookup cost is a worthy trade-off for tighter auth.

**Improvements**:
- @karrui mentioned that including a flag to check if a user was soft deleted / their session was invalidated (ironsession is stateless) would be a better way to handle this. 

