### PR TITLE
feat: add error boundaries and suspense usage with TRPC

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,11 @@
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
+    "no-restricted-imports": ["error", {
+      "paths": [
+        {"name": "react", "importNames": ["Suspense"], "message": "Please user Suspense from /components instead. Default React 18 Suspense is not supported for SSR"}
+      ]
+    }],
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
     "@typescript-eslint/no-explicit-any": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,7 @@
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "no-restricted-imports": ["error", {
       "paths": [
-        {"name": "react", "importNames": ["Suspense"], "message": "Please user Suspense from /components instead. Default React 18 Suspense is not supported for SSR"}
+        {"name": "react", "importNames": ["Suspense"], "message": "Please use Suspense from /components instead. Default React 18 Suspense is not supported for SSR"}
       ]
     }],
     "react/react-in-jsx-scope": "off",

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -20,7 +20,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
   componentDidCatch(error: Error) {
     // You can use your own error logging service here
-    console.log({ error })
+    console.error(error)
   }
 
   render() {

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { Component } from 'react'
 import { ErrorBoundaryProps, ErrorBoundaryState } from './ErrorBoundary.types'
 import { TRPCWithErrorCodeSchema } from '../../utils/error'
 import { UnexpectedErrorCard } from './UnexpectedErrorCard'
+import { CALLBACK_URL_KEY } from '~/constants/params'
 
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
@@ -44,7 +45,14 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       // Using next's router.push('/sign-in') will not render the SignIn component as it won't be mounted in the app root as the ErrorBoundary fallback component will be rendered instead
       // Using vanilla location redirecting will prompt a full page reload of /sign-in page, which will never trigger the root ErrorBoundary, thus rendering the full component correctly
       if (res.data === 'UNAUTHORIZED') {
-        window.location.href = 'sign-in'
+        const params = new URLSearchParams(window.location.search)
+
+        const callbackUrl = params.get('callbackUrl')
+
+        window.location.href = !!callbackUrl
+          ? `sign-in/?${CALLBACK_URL_KEY}=${callbackUrl}`
+          : `sign-in`
+
         return
       }
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,62 @@
+import { Box } from '@chakra-ui/react'
+import { TRPCClientError } from '@trpc/client'
+import { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc'
+import { Component, ReactNode } from 'react'
+import { ErrorBoundaryProps, ErrorBoundaryState } from './ErrorBoundary.types'
+import { TRPCWithErrorCodeSchema } from './ErrorBoundary.utils'
+import { UnexpectedErrorCard } from './UnexpectedErrorCard'
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+
+    // Define a state variable to track whether is an error or not
+    this.state = { hasError: false }
+  }
+  static getDerivedStateFromError(error: unknown) {
+    // Update state so the next render will show the fallback UI
+    return { hasError: true, error }
+  }
+  componentDidCatch(error: Error) {
+    // You can use your own error logging service here
+    console.log({ error })
+  }
+
+  render() {
+    const { children, fallback } = this.props
+    const error = this.state.error
+
+    // Check if the error is thrown
+    if (!this.state.hasError) {
+      return children
+    }
+
+    if (fallback !== undefined) {
+      return fallback
+    }
+
+    if (error instanceof TRPCClientError) {
+      const isTRPCErrorShape = TRPCWithErrorCodeSchema.safeParse(error)
+
+      if (!isTRPCErrorShape.success) return <UnexpectedErrorCard />
+
+      return getErrorComponent(isTRPCErrorShape.data.data.code)
+    }
+  }
+}
+
+// TODO: Make custom components for these
+function getErrorComponent(code: TRPC_ERROR_CODE_KEY): ReactNode {
+  switch (code) {
+    case 'NOT_FOUND':
+      return (
+        <Box bgColor="red" width="100px" height="100px">
+          Not found!
+        </Box>
+      )
+    default:
+      return <UnexpectedErrorCard />
+  }
+}
+
+export default ErrorBoundary

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -62,7 +62,11 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 }
 
 // TODO: Make custom components for these
-function ErrorComponent({ code }: { code: TRPC_ERROR_CODE_KEY }) {
+function ErrorComponent({
+  code,
+}: {
+  code: Exclude<TRPC_ERROR_CODE_KEY, 'UNAUTHORIZED'>
+}) {
   switch (code) {
     case 'NOT_FOUND':
       return (

--- a/src/components/ErrorBoundary/ErrorBoundary.types.ts
+++ b/src/components/ErrorBoundary/ErrorBoundary.types.ts
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react'
+
+export type ErrorBoundaryState = {
+  hasError: boolean
+  error?: unknown
+}
+
+export type ErrorBoundaryProps = {
+  children: ReactNode
+  fallback?: ReactNode
+}

--- a/src/components/ErrorBoundary/ErrorBoundary.utils.ts
+++ b/src/components/ErrorBoundary/ErrorBoundary.utils.ts
@@ -1,0 +1,10 @@
+import { TRPC_ERROR_CODES_BY_KEY, TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc'
+import { z } from 'zod'
+
+const TRPC_ERROR_CODE_KEY_ENUM = Object.keys(
+  TRPC_ERROR_CODES_BY_KEY
+) as unknown as [TRPC_ERROR_CODE_KEY, ...TRPC_ERROR_CODE_KEY[]]
+
+export const TRPCWithErrorCodeSchema = z.object({
+  data: z.object({ code: z.enum(TRPC_ERROR_CODE_KEY_ENUM) }),
+})

--- a/src/components/ErrorBoundary/UnexpectedErrorCard.tsx
+++ b/src/components/ErrorBoundary/UnexpectedErrorCard.tsx
@@ -1,0 +1,7 @@
+export const UnexpectedErrorCard = () => {
+  return (
+    <div>
+      <h2>Oops, an unexpected error occurred!</h2>
+    </div>
+  )
+}

--- a/src/components/Suspense/Suspense.tsx
+++ b/src/components/Suspense/Suspense.tsx
@@ -8,8 +8,8 @@ import {
 } from 'react'
 
 export default function Suspense(props: ComponentProps<typeof ReactSuspense>) {
-  // This is needed so we only attempt to render and fire the queries within the suspense wrapper on client side mount
-  // Not doing this will cause an error that the router instance has not been instantiated, and also will call queries outside of TRPC context
+  // Tracking mounted state is needed so we only attempt to render and fire the queries within the suspense wrapper on mount instead
+  // Not doing this will cause an error that the router instance has not been instantiated, and also will call trpc routes uninstantiated context
   const [isMounted, setIsMounted] = useState(false)
   const router = useRouter()
 

--- a/src/components/Suspense/Suspense.tsx
+++ b/src/components/Suspense/Suspense.tsx
@@ -1,0 +1,22 @@
+import {
+  ComponentProps,
+  // eslint-disable-next-line no-restricted-imports
+  Suspense as ReactSuspense,
+  useEffect,
+  useState,
+} from 'react'
+
+export default function Suspense(props: ComponentProps<typeof ReactSuspense>) {
+  // This is needed so we only attempt to zrender and fire te queries within the suspense wrapper on client side mount
+  // Not doing this will cause an error that the router instance has not been instantiated, and also will call queries outside of TRPC context
+  const [isMounted, setIsMounted] = useState(false)
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  if (isMounted) {
+    return <ReactSuspense {...props} />
+  }
+  return <>{props.fallback}</>
+}

--- a/src/components/Suspense/Suspense.tsx
+++ b/src/components/Suspense/Suspense.tsx
@@ -14,6 +14,8 @@ export default function Suspense(props: ComponentProps<typeof ReactSuspense>) {
   const router = useRouter()
 
   useEffect(() => {
+    // isReady conditional is needed so that suspenseQueries do not fire twice.
+    // Without this, the child component will fire a query with an `undefined` query param followed by the actual query with param defined
     if (router.isReady) {
       setIsMounted(true)
     }

--- a/src/components/Suspense/Suspense.tsx
+++ b/src/components/Suspense/Suspense.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import {
   ComponentProps,
   // eslint-disable-next-line no-restricted-imports
@@ -7,13 +8,16 @@ import {
 } from 'react'
 
 export default function Suspense(props: ComponentProps<typeof ReactSuspense>) {
-  // This is needed so we only attempt to zrender and fire te queries within the suspense wrapper on client side mount
+  // This is needed so we only attempt to render and fire the queries within the suspense wrapper on client side mount
   // Not doing this will cause an error that the router instance has not been instantiated, and also will call queries outside of TRPC context
   const [isMounted, setIsMounted] = useState(false)
+  const router = useRouter()
 
   useEffect(() => {
-    setIsMounted(true)
-  }, [])
+    if (router.isReady) {
+      setIsMounted(true)
+    }
+  }, [router.isReady])
 
   if (isMounted) {
     return <ReactSuspense {...props} />

--- a/src/constants/params.ts
+++ b/src/constants/params.ts
@@ -1,0 +1,1 @@
+export const CALLBACK_URL_KEY = 'callbackUrl' as const

--- a/src/features/feedback/api/useFilterFeedback.ts
+++ b/src/features/feedback/api/useFilterFeedback.ts
@@ -66,19 +66,13 @@ export const useFilterFeedback = () => {
     [router]
   )
 
-  const {
-    data: filteredFeedback,
-    isLoading,
-    isFetching,
-  } = trpc.post.list.useQuery(
+  const [filteredFeedback] = trpc.post.list.useSuspenseQuery(
     { order, filter, cursor, limit },
     { keepPreviousData: true }
   )
 
   return {
     filteredFeedback,
-    isLoading,
-    isFetching,
     filter: {
       value: filter,
       label: FILTER_VAL_TO_LABEL[filter],

--- a/src/features/feedback/components/FeedbackHeader.tsx
+++ b/src/features/feedback/components/FeedbackHeader.tsx
@@ -1,0 +1,41 @@
+import { Stack, Text, Icon } from '@chakra-ui/react'
+import { BiPlus } from 'react-icons/bi'
+import { trpc } from '~/utils/trpc'
+import Image from 'next/image'
+import feedbackUncleSvg from '~/features/feedback/assets/feedback-uncle.svg'
+import { Button } from '@opengovsg/design-system-react'
+import NextLink from 'next/link'
+
+export const FeedbackHeader = () => {
+  const [counts] = trpc.post.unreadCount.useSuspenseQuery()
+
+  return (
+    <Stack justify="space-between" flexDir="row">
+      <Stack flexDir="row" align="center">
+        <Image
+          height={72}
+          priority
+          style={{
+            transform: 'scale(-1,1)',
+          }}
+          src={feedbackUncleSvg}
+          aria-hidden
+          alt="Feedback uncle"
+        />
+        <Text textStyle="subhead-1" color="base.content.medium">
+          <Text as="span" textStyle="h4" color="base.content.default">
+            {counts?.unreadCount ?? 0}
+          </Text>{' '}
+          unread feedback of {counts?.totalCount ?? 0}
+        </Text>
+      </Stack>
+      <Button
+        as={NextLink}
+        href="/feedback/new"
+        leftIcon={<Icon fontSize="1.25rem" as={BiPlus} />}
+      >
+        Write feedback
+      </Button>
+    </Stack>
+  )
+}

--- a/src/features/feedback/components/TeamFeedbackFilterBar.tsx
+++ b/src/features/feedback/components/TeamFeedbackFilterBar.tsx
@@ -49,7 +49,7 @@ const FilterSelect = ({
 }
 
 export const TeamFeedbackFilterBar = (): JSX.Element => {
-  const { filter, order, handleFilterChange, handleOrderChange, isLoading } =
+  const { filter, order, handleFilterChange, handleOrderChange } =
     useFilterFeedback()
 
   return (
@@ -59,16 +59,8 @@ export const TeamFeedbackFilterBar = (): JSX.Element => {
       borderBottomWidth="1px"
       borderColor="base.divider.medium"
     >
-      <FilterSelect
-        selection={filter}
-        isDisabled={isLoading}
-        onChange={handleFilterChange}
-      />
-      <FilterSelect
-        selection={order}
-        isDisabled={isLoading}
-        onChange={handleOrderChange}
-      />
+      <FilterSelect selection={filter} onChange={handleFilterChange} />
+      <FilterSelect selection={order} onChange={handleOrderChange} />
     </Box>
   )
 }

--- a/src/features/feedback/components/TeamFeedbackList.tsx
+++ b/src/features/feedback/components/TeamFeedbackList.tsx
@@ -1,19 +1,14 @@
 import { Box, Stack, StackDivider } from '@chakra-ui/react'
 import { useFilterFeedback } from '../api/useFilterFeedback'
-import { TeamFeedbackListSkeleton } from './TeamFeedbackListSkeleton'
 import { TeamFeedbackRow } from './TeamFeedbackRow'
 
 export const TeamFeedbackList = (): JSX.Element => {
-  const { filteredFeedback, isFetching } = useFilterFeedback()
-
-  if (!filteredFeedback) {
-    return <TeamFeedbackListSkeleton />
-  }
+  const { filteredFeedback } = useFilterFeedback()
 
   return (
     <Stack divider={<StackDivider />} spacing={0}>
       {filteredFeedback?.items.map((feedback) => (
-        <Box key={feedback.id} opacity={isFetching ? 0.7 : 1}>
+        <Box key={feedback.id}>
           <TeamFeedbackRow feedback={feedback} />
         </Box>
       ))}

--- a/src/features/profile/api/useUser.ts
+++ b/src/features/profile/api/useUser.ts
@@ -1,27 +1,15 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 import Router from 'next/router'
 import { trpc } from '~/utils/trpc'
 
 export const useUser = ({ redirectTo = '', redirectIfFound = false } = {}) => {
-  const { data: user, isFetching, ...rest } = trpc.me.get.useQuery()
-
-  useEffect(() => {
-    // if no redirect needed, just return (example: already on /dashboard)
-    // if user data not yet there (fetch in progress, logged in or not) then don't do anything yet
-    if (!redirectTo || isFetching) return
-
-    const shouldRedirect =
-      // If redirectTo is set,
-      redirectTo &&
-      // redirect if the user was not found.
-      ((!redirectIfFound && !user) ||
-        // If redirectIfFound is also set, redirect if the user was found
-        (redirectIfFound && user))
-
-    if (shouldRedirect) {
-      Router.push(redirectTo)
-    }
-  }, [user, redirectIfFound, redirectTo, isFetching])
+  const [user] = trpc.me.get.useSuspenseQuery(undefined, {
+    onSuccess: () => {
+      if (redirectIfFound) {
+        Router.push(redirectTo)
+      }
+    },
+  })
 
   const logoutMutation = trpc.auth.logout.useMutation()
 
@@ -36,5 +24,5 @@ export const useUser = ({ redirectTo = '', redirectIfFound = false } = {}) => {
     [logoutMutation]
   )
 
-  return { user, isFetching, ...rest, logout }
+  return { user, logout }
 }

--- a/src/features/sign-in/components/SignInContext.tsx
+++ b/src/features/sign-in/components/SignInContext.tsx
@@ -1,0 +1,54 @@
+import { SetStateAction } from 'jotai'
+import {
+  createContext,
+  Dispatch,
+  PropsWithChildren,
+  useContext,
+  useState,
+} from 'react'
+
+type SignInStates = {
+  timer: number
+  setTimer: Dispatch<SetStateAction<number>>
+  email: string
+  setEmail: Dispatch<SetStateAction<string>>
+  showVerificationStep: boolean
+  setShowVerificationStep: Dispatch<SetStateAction<boolean>>
+}
+
+export const SignInContext = createContext<SignInStates | undefined>(undefined)
+
+export const useSignInContext = () => {
+  const context = useContext(SignInContext)
+
+  if (context === undefined) {
+    throw new Error(
+      `Must use sign in context within ${SignInContextProvider}.name`
+    )
+  }
+
+  return context
+}
+
+export const SignInContextProvider: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const [email, setEmail] = useState('')
+  const [showVerificationStep, setShowVerificationStep] = useState(false)
+  const [timer, setTimer] = useState(60)
+
+  return (
+    <SignInContext.Provider
+      value={{
+        email,
+        setEmail,
+        showVerificationStep,
+        setShowVerificationStep,
+        timer,
+        setTimer,
+      }}
+    >
+      {children}
+    </SignInContext.Provider>
+  )
+}

--- a/src/features/sign-in/components/SignInForm.tsx
+++ b/src/features/sign-in/components/SignInForm.tsx
@@ -1,21 +1,23 @@
-import { useState } from 'react'
+import { useCallback } from 'react'
+import { useSignInContext } from './SignInContext'
 import { EmailInput } from './Emailnput'
 import { VerificationInput } from './VerificationInput'
 
 export const SignInForm = () => {
-  const [email, setEmail] = useState('')
-  const [showVerificationStep, setShowVerificationStep] = useState(false)
+  const { showVerificationStep, setEmail, setShowVerificationStep } =
+    useSignInContext()
+
+  const handleOnSuccessEmail = useCallback(
+    (email: string) => {
+      setEmail(email)
+      setShowVerificationStep(true)
+    },
+    [setEmail, setShowVerificationStep]
+  )
 
   if (showVerificationStep) {
-    return <VerificationInput email={email} />
+    return <VerificationInput />
   }
 
-  return (
-    <EmailInput
-      onSuccess={(email) => {
-        setEmail(email)
-        setShowVerificationStep(true)
-      }}
-    />
-  )
+  return <EmailInput onSuccess={handleOnSuccessEmail} />
 }

--- a/src/features/sign-in/components/VerificationInput.tsx
+++ b/src/features/sign-in/components/VerificationInput.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { useIntervalWhen } from 'rooks'
 import { z } from 'zod'
+import { CALLBACK_URL_KEY } from '~/constants/params'
 import { useZodForm } from '~/lib/form'
 import { trpc } from '~/utils/trpc'
 import { emailSignInSchema } from './Emailnput'
@@ -63,7 +64,7 @@ export const VerificationInput = ({
       },
       {
         onSuccess: () => {
-          router.push(String(router.query.callbackUrl ?? '/dashboard'))
+          router.push(String(router.query[CALLBACK_URL_KEY] ?? '/dashboard'))
         },
       }
     )

--- a/src/features/sign-in/components/VerificationInput.tsx
+++ b/src/features/sign-in/components/VerificationInput.tsx
@@ -53,7 +53,6 @@ export const VerificationInput = (): JSX.Element => {
   })
 
   const handleVerifyOtp = handleSubmit(({ email, token }) => {
-    console.log('>>> submitting')
     return verifyOtpMutation.mutate(
       {
         email,
@@ -61,11 +60,7 @@ export const VerificationInput = (): JSX.Element => {
       },
       {
         onSuccess: () => {
-          console.log('>> testing')
           router.push(String(router.query[CALLBACK_URL_KEY] ?? '/dashboard'))
-        },
-        onError: (e) => {
-          console.log('>>> error', e)
         },
       }
     )

--- a/src/features/sign-in/components/VerificationInput.tsx
+++ b/src/features/sign-in/components/VerificationInput.tsx
@@ -1,12 +1,12 @@
 import { FormControl, FormLabel, Stack } from '@chakra-ui/react'
 import { Button, FormErrorMessage, Input } from '@opengovsg/design-system-react'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
 import { useIntervalWhen } from 'rooks'
 import { z } from 'zod'
 import { CALLBACK_URL_KEY } from '~/constants/params'
 import { useZodForm } from '~/lib/form'
 import { trpc } from '~/utils/trpc'
+import { useSignInContext } from './SignInContext'
 import { emailSignInSchema } from './Emailnput'
 import { ResendOtpButton } from './ResendOtpButton'
 
@@ -18,14 +18,18 @@ const emailVerificationSchema = emailSignInSchema.extend({
     .length(6, 'Please enter a 6 character OTP.'),
 })
 
-interface VerificationInputProps {
-  email: string
-}
-
-export const VerificationInput = ({
-  email,
-}: VerificationInputProps): JSX.Element => {
+export const VerificationInput = (): JSX.Element => {
   const router = useRouter()
+
+  const { email, timer, setTimer } = useSignInContext()
+
+  useIntervalWhen(
+    () => setTimer(timer - 1),
+    /* intervalDurationMs= */ 1000,
+    // Stop interval if timer hits 0.
+    /* when= */ timer > 0
+  )
+
   const {
     register,
     handleSubmit,
@@ -38,14 +42,6 @@ export const VerificationInput = ({
     },
   })
 
-  const [timer, setTimer] = useState(60)
-  useIntervalWhen(
-    () => setTimer(timer - 1),
-    /* intervalDurationMs= */ 1000,
-    // Stop interval if timer hits 0.
-    /* when= */ timer > 0
-  )
-
   const verifyOtpMutation = trpc.auth.email.verifyOtp.useMutation({
     onError: (error) => {
       setError('token', { message: error.message })
@@ -57,6 +53,7 @@ export const VerificationInput = ({
   })
 
   const handleVerifyOtp = handleSubmit(({ email, token }) => {
+    console.log('>>> submitting')
     return verifyOtpMutation.mutate(
       {
         email,
@@ -64,7 +61,11 @@ export const VerificationInput = ({
       },
       {
         onSuccess: () => {
+          console.log('>> testing')
           router.push(String(router.query[CALLBACK_URL_KEY] ?? '/dashboard'))
+        },
+        onError: (e) => {
+          console.log('>>> error', e)
         },
       }
     )

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,26 +9,49 @@ import { DefaultLayout } from '~/templates/layouts/DefaultLayout'
 import { theme } from '~/theme'
 import { trpc } from '~/utils/trpc'
 import { Provider } from 'jotai'
+import Suspense from '~/components/Suspense/Suspense'
+import ErrorBoundary from '~/components/ErrorBoundary/ErrorBoundary'
+import { Skeleton } from '@chakra-ui/react'
 
 type AppPropsWithAuthAndLayout = AppProps & {
   Component: NextPageWithLayout
 }
 
-const MyApp = (({ Component, pageProps }: AppPropsWithAuthAndLayout) => {
-  const getLayout =
-    Component.getLayout ?? ((page) => <DefaultLayout>{page}</DefaultLayout>)
-
+const MyApp = (({
+  Component,
+  pageProps,
+  ...props
+}: AppPropsWithAuthAndLayout) => {
   return (
     // Must wrap Jotai's provider in SSR context, see https://jotai.org/docs/guides/nextjs#provider.
     <Provider>
       <ThemeProvider theme={theme}>
-        {getLayout(<Component {...pageProps} />)}
-        {process.env.NODE_ENV !== 'production' && (
-          <ReactQueryDevtools initialIsOpen={false} />
-        )}
+        <ErrorBoundary>
+          <Suspense fallback={<Skeleton width="100vw" height="100vh" />}>
+            <ChildWithLayout
+              Component={Component}
+              pageProps={pageProps}
+              {...props}
+            />
+            {process.env.NODE_ENV !== 'production' && (
+              <ReactQueryDevtools initialIsOpen={false} />
+            )}
+          </Suspense>
+        </ErrorBoundary>
       </ThemeProvider>
     </Provider>
   )
 }) as AppType
+
+// This is needed so suspense will be triggered for anything within the LayoutComponents which uses useSuspenseQuery
+const ChildWithLayout = ({
+  Component,
+  pageProps,
+}: AppPropsWithAuthAndLayout) => {
+  const getLayout =
+    Component.getLayout ?? ((page) => <DefaultLayout>{page}</DefaultLayout>)
+
+  return <>{getLayout(<Component {...pageProps} />)}</>
+}
 
 export default trpc.withTRPC(MyApp)

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -17,22 +17,14 @@ type AppPropsWithAuthAndLayout = AppProps & {
   Component: NextPageWithLayout
 }
 
-const MyApp = (({
-  Component,
-  pageProps,
-  ...props
-}: AppPropsWithAuthAndLayout) => {
+const MyApp = ((props: AppPropsWithAuthAndLayout) => {
   return (
     // Must wrap Jotai's provider in SSR context, see https://jotai.org/docs/guides/nextjs#provider.
     <Provider>
       <ThemeProvider theme={theme}>
         <ErrorBoundary>
           <Suspense fallback={<Skeleton width="100vw" height="100vh" />}>
-            <ChildWithLayout
-              Component={Component}
-              pageProps={pageProps}
-              {...props}
-            />
+            <ChildWithLayout {...props} />
             {process.env.NODE_ENV !== 'production' && (
               <ReactQueryDevtools initialIsOpen={false} />
             )}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,64 +1,49 @@
-import { Box, Icon, Skeleton, Stack, Text } from '@chakra-ui/react'
-import { Button } from '@opengovsg/design-system-react'
-import Image from 'next/image'
-import NextLink from 'next/link'
-import { BiPlus } from 'react-icons/bi'
-import feedbackUncleSvg from '~/features/feedback/assets/feedback-uncle.svg'
+import { Box, Skeleton } from '@chakra-ui/react'
 import {
   FeedbackActionsModal,
   TeamFeedbackList,
 } from '~/features/feedback/components'
 import type { NextPageWithLayout } from '~/lib/types'
 import { AdminLayout } from '~/templates/layouts/AdminLayout'
-import { trpc } from '~/utils/trpc'
 import { TeamFeedbackFilterBar } from '~/features/feedback/components/TeamFeedbackFilterBar'
+import Suspense from '~/components/Suspense/Suspense'
+import { TeamFeedbackListSkeleton } from '~/features/feedback/components/TeamFeedbackListSkeleton'
+import ErrorBoundary from '~/components/ErrorBoundary/ErrorBoundary'
+import { FeedbackHeader } from '~/features/feedback/components/FeedbackHeader'
 
 const Dashboard: NextPageWithLayout = () => {
-  const { data: counts, isLoading: unreadCountIsLoading } =
-    trpc.post.unreadCount.useQuery()
-
   return (
     <Box p="1.5rem" w="100%">
+      <ErrorBoundary>
+        <Suspense fallback={<Skeleton height="100%" width="100%" />}>
+          <DashboardContainer />
+        </Suspense>
+      </ErrorBoundary>
+
       <FeedbackActionsModal />
-      <Stack justify="space-between" flexDir="row">
-        <Stack flexDir="row" align="center">
-          <Image
-            height={72}
-            priority
-            style={{
-              transform: 'scale(-1,1)',
-            }}
-            src={feedbackUncleSvg}
-            aria-hidden
-            alt="Feedback uncle"
-          />
-          <Skeleton isLoaded={!unreadCountIsLoading}>
-            <Text textStyle="subhead-1" color="base.content.medium">
-              <Text as="span" textStyle="h4" color="base.content.default">
-                {counts?.unreadCount ?? 0}
-              </Text>{' '}
-              unread feedback of {counts?.totalCount ?? 0}
-            </Text>
-          </Skeleton>
-        </Stack>
-        <Button
-          as={NextLink}
-          href="/feedback/new"
-          leftIcon={<Icon fontSize="1.25rem" as={BiPlus} />}
-        >
-          Write feedback
-        </Button>
-      </Stack>
-      <Box
-        bg="white"
-        borderRadius="sm"
-        borderWidth="1px"
-        borderColor="base.divider.medium"
-      >
-        <TeamFeedbackFilterBar />
-        <TeamFeedbackList />
-      </Box>
     </Box>
+  )
+}
+
+const DashboardContainer = () => {
+  return (
+    <>
+      <Suspense fallback={<Skeleton height="100px" width="100%" />}>
+        <FeedbackHeader />
+      </Suspense>
+
+      <Suspense fallback={<TeamFeedbackListSkeleton />}>
+        <Box
+          bg="white"
+          borderRadius="sm"
+          borderWidth="1px"
+          borderColor="base.divider.medium"
+        >
+          <TeamFeedbackFilterBar />
+          <TeamFeedbackList />
+        </Box>
+      </Suspense>
+    </>
   )
 }
 

--- a/src/pages/feedback/[id].tsx
+++ b/src/pages/feedback/[id].tsx
@@ -1,5 +1,4 @@
-import { Container, Flex, Stack, Text } from '@chakra-ui/react'
-import { Spinner } from '@opengovsg/design-system-react'
+import { Container, Flex, Spinner, Stack, Text } from '@chakra-ui/react'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo } from 'react'
 import ErrorBoundary from '~/components/ErrorBoundary/ErrorBoundary'
@@ -28,10 +27,8 @@ const PostViewContainer = () => {
 
   const utils = trpc.useContext()
 
-  const { data } = trpc.post.byId.useQuery(
-    { id },
-    { suspense: true, enabled: router.isReady }
-  )
+  const [data] = trpc.post.byId.useSuspenseQuery({ id })
+
   const { mutate } = trpc.post.setRead.useMutation()
 
   const viewPostCrumbs = useMemo(() => {

--- a/src/pages/feedback/[id].tsx
+++ b/src/pages/feedback/[id].tsx
@@ -28,8 +28,11 @@ const PostViewContainer = () => {
 
   const utils = trpc.useContext()
 
+  const { data } = trpc.post.byId.useQuery(
+    { id },
+    { suspense: true, enabled: router.isReady }
+  )
   const { mutate } = trpc.post.setRead.useMutation()
-  const [data] = trpc.post.byId.useSuspenseQuery({ id })
 
   const viewPostCrumbs = useMemo(() => {
     return [
@@ -46,18 +49,24 @@ const PostViewContainer = () => {
   }, [data?.author.name, id])
 
   useEffect(() => {
-    mutate(
-      { id },
-      {
-        onSuccess: () => {
-          utils.post.list.invalidate()
-          utils.post.unreadCount.invalidate()
-        },
-      }
-    )
+    if (router.isReady) {
+      mutate(
+        { id },
+        {
+          onSuccess: () => {
+            utils.post.list.invalidate()
+            utils.post.unreadCount.invalidate()
+          },
+        }
+      )
+    }
     // Only want to run once on mount.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [router.isReady])
+
+  if (!data) {
+    return <></>
+  }
 
   return (
     <>

--- a/src/pages/feedback/[id].tsx
+++ b/src/pages/feedback/[id].tsx
@@ -1,37 +1,35 @@
 import { Container, Flex, Stack, Text } from '@chakra-ui/react'
-import { type InferGetServerSidePropsType } from 'next'
+import { Spinner } from '@opengovsg/design-system-react'
+import { useRouter } from 'next/router'
 import { useEffect, useMemo } from 'react'
+import ErrorBoundary from '~/components/ErrorBoundary/ErrorBoundary'
+import Suspense from '~/components/Suspense/Suspense'
 import { FeedbackComment, FeedbackNavbar } from '~/features/feedback/components'
 import { FeedbackCommentRichText } from '~/features/feedback/components/FeedbackCommentRichText'
-import { createSsgHelper } from '~/lib/ssg'
 import { type NextPageWithLayout } from '~/lib/types'
-import { withSessionSsr } from '~/lib/withSession'
 import { trpc } from '~/utils/trpc'
 
-const PostViewPage: NextPageWithLayout<
-  InferGetServerSidePropsType<typeof getServerSideProps>
-> = (props) => {
-  const { id } = props
+const PostViewPage: NextPageWithLayout = () => {
+  return (
+    <Flex flexDir="column" bg="base.canvas.brand-subtle" minH="$100vh">
+      <ErrorBoundary>
+        <Suspense fallback={<Spinner />}>
+          <PostViewContainer />
+        </Suspense>
+      </ErrorBoundary>
+    </Flex>
+  )
+}
+
+const PostViewContainer = () => {
+  const router = useRouter()
+
+  const id = String(router.query.id)
+
   const utils = trpc.useContext()
 
   const { mutate } = trpc.post.setRead.useMutation()
-
-  useEffect(() => {
-    mutate(
-      { id },
-      {
-        onSuccess: () => {
-          utils.post.list.invalidate()
-          utils.post.unreadCount.invalidate()
-        },
-      }
-    )
-    // Only want to run once on mount.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  // This query will be immediately available as it's prefetched.
-  const { data, isSuccess } = trpc.post.byId.useQuery({ id })
+  const [data] = trpc.post.byId.useSuspenseQuery({ id })
 
   const viewPostCrumbs = useMemo(() => {
     return [
@@ -47,13 +45,24 @@ const PostViewPage: NextPageWithLayout<
     ]
   }, [data?.author.name, id])
 
-  if (!isSuccess) {
-    return <div>Should not happen</div>
-  }
+  useEffect(() => {
+    mutate(
+      { id },
+      {
+        onSuccess: () => {
+          utils.post.list.invalidate()
+          utils.post.unreadCount.invalidate()
+        },
+      }
+    )
+    // Only want to run once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
-    <Flex flexDir="column" bg="base.canvas.brand-subtle" minH="$100vh">
+    <>
       <FeedbackNavbar crumbs={viewPostCrumbs} />
+
       <Container my="3.5rem">
         <Stack mb="1.25rem">
           <Text as="h1" textStyle="h4">
@@ -82,33 +91,8 @@ const PostViewPage: NextPageWithLayout<
           <FeedbackCommentRichText postId={data.id} />
         </Stack>
       </Container>
-    </Flex>
+    </>
   )
 }
-
-export const getServerSideProps = withSessionSsr(
-  async function getServerSideProps({ req, params }) {
-    const ssg = await createSsgHelper(req.session)
-    const id = params?.id as string
-
-    try {
-      // Fetch `post.byId` so the data is cached in queryClient.
-      await ssg.post.byId.fetch({ id })
-
-      return {
-        props: {
-          trpcState: ssg.dehydrate(),
-          id,
-        },
-      }
-    } catch (err) {
-      return {
-        // If failed, return 404
-        props: { id },
-        notFound: true,
-      }
-    }
-  }
-)
 
 export default PostViewPage

--- a/src/pages/feedback/[id].tsx
+++ b/src/pages/feedback/[id].tsx
@@ -61,10 +61,6 @@ const PostViewContainer = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.isReady])
 
-  if (!data) {
-    return <></>
-  }
-
   return (
     <>
       <FeedbackNavbar crumbs={viewPostCrumbs} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,7 +9,6 @@ const Index = () => {
 
 export const getServerSideProps = withSessionSsr(async ({ req }) => {
   const user = req.session.user
-
   if (user) {
     return {
       redirect: {

--- a/src/pages/sign-in.tsx
+++ b/src/pages/sign-in.tsx
@@ -22,7 +22,7 @@ import { trpc } from '~/utils/trpc'
 const title = browserEnv.NEXT_PUBLIC_APP_NAME
 
 const SignIn = () => {
-  useShowSignInForm()
+  useRedirectIfSignedIn()
 
   return (
     <BackgroundBox>
@@ -68,7 +68,7 @@ const SignIn = () => {
 }
 
 // This hook is only meant to be used in `sign-in` page
-function useShowSignInForm() {
+function useRedirectIfSignedIn() {
   const router = useRouter()
 
   const callbackUrl =

--- a/src/pages/sign-in.tsx
+++ b/src/pages/sign-in.tsx
@@ -3,6 +3,7 @@ import { Box, Flex, Text } from '@chakra-ui/react'
 import { RestrictedGovtMasthead } from '@opengovsg/design-system-react'
 import { browserEnv } from '~/browserEnv'
 import { MiniFooter } from '~/components/Footer/MiniFooter'
+import { CALLBACK_URL_KEY } from '~/constants/params'
 import {
   BackgroundBox,
   BaseGridLayout,
@@ -57,7 +58,7 @@ const SignIn = () => {
 
 export const getServerSideProps = withSessionSsr(
   async function getServerSideProps({ req, query }) {
-    const { callbackUrl } = query
+    const callbackUrl = query[CALLBACK_URL_KEY]
     const user = req.session.user
 
     if (user) {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -5,6 +5,8 @@ const TRPC_ERROR_CODE_KEY_ENUM = Object.keys(
   TRPC_ERROR_CODES_BY_KEY
 ) as unknown as [TRPC_ERROR_CODE_KEY, ...TRPC_ERROR_CODE_KEY[]]
 
-export const TRPCWithErrorCodeSchema = z.object({
-  data: z.object({ code: z.enum(TRPC_ERROR_CODE_KEY_ENUM) }),
-})
+export const TRPCWithErrorCodeSchema = z
+  .object({
+    data: z.object({ code: z.enum(TRPC_ERROR_CODE_KEY_ENUM) }),
+  })
+  .transform((data) => data.data.code)

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -28,11 +28,7 @@ export interface SSRContext extends NextPageContext {
  * A set of strongly-typed React hooks from your `AppRouter` type signature with `createReactQueryHooks`.
  * @link https://trpc.io/docs/react#3-create-trpc-hooks
  */
-export const trpc = createTRPCNext<
-  AppRouter,
-  SSRContext,
-  'ExperimentalSuspense'
->({
+export const trpc = createTRPCNext<AppRouter, SSRContext>({
   config({ ctx }) {
     /**
      * If you want to use SSR, you need to use the server's full URL

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -28,7 +28,11 @@ export interface SSRContext extends NextPageContext {
  * A set of strongly-typed React hooks from your `AppRouter` type signature with `createReactQueryHooks`.
  * @link https://trpc.io/docs/react#3-create-trpc-hooks
  */
-export const trpc = createTRPCNext<AppRouter, SSRContext>({
+export const trpc = createTRPCNext<
+  AppRouter,
+  SSRContext,
+  'ExperimentalSuspense'
+>({
   config({ ctx }) {
     /**
      * If you want to use SSR, you need to use the server's full URL
@@ -79,6 +83,7 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
         defaultOptions: {
           queries: {
             staleTime: 1000 * 10, // 10 seconds
+            useErrorBoundary: true,
             retry: (failureCount, error) => {
               if (error instanceof TRPCClientError) {
                 if (error.data?.code === 'FORBIDDEN') {

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -28,7 +28,11 @@ export interface SSRContext extends NextPageContext {
  * A set of strongly-typed React hooks from your `AppRouter` type signature with `createReactQueryHooks`.
  * @link https://trpc.io/docs/react#3-create-trpc-hooks
  */
-export const trpc = createTRPCNext<AppRouter, SSRContext>({
+export const trpc = createTRPCNext<
+  AppRouter,
+  SSRContext,
+  'ExperimentalSuspense'
+>({
   config({ ctx }) {
     /**
      * If you want to use SSR, you need to use the server's full URL


### PR DESCRIPTION
## Problem

### Problem 1
Our current method of fetching data for pages with query params utilize `getServerSideProps`. We noticed a trend of slow initial load times for these pages as long as ~7s. This is likely (but not confirmed) attributed to Chakra's huge bundle size which slows down the time needed to build the server rendered page.

### Solutions considered to root problem

We had two options

- Attempt to fix `getServerSideProps`'s bundle issues with Chakra - possibly looking into how we can treeshake chakra for server rendered pages to reduce build times
- Introduce CSR patterns in our application

We went with option 2 as that was already in the existing roadmap.

### Problem 2

Existing CSR patterns with page based routing was cumbersome as we could not use React 18's `Suspense` and the default `ErrorBoundary` from `react-error-boundary`. 

This led to 2 dx issues:
- In every component where we use query, we had to track `isLoading` and `isError` states and render the fallback components accordingly
- There was a lack of a top level `ErrorBoundary` which would catch any errors thrown within child components which `useSuspenseQuery`

### Solution 
- The inability to use React's `Suspense` component was due to the fact that any child component which calls the `useRouter` hook erroring out during server side rendering as the router had not mounted. T
    - To mitigate this, we created our own `Suspense` wrapper that keeps track of a `isMounted` state. 
        -  If the router is ready, we will render React's `Suspense` with the children
        - If router is not ready, `fallbackComponent` will render.  
- Created our own `ErrorBoundary` wrapper which catches error boundary states to render the correct fallback components

**Improvements**:
- Refactored all queries to utilise `useSuspenseQuery`
- Updated logic to handle redirects between `sign-in` and `dashboard`
- Updated centralised logic for unauthorised errors redirecting to `sign-in`. This logic for this is now located in the `ErrorBoundary` component whenever a TRPCError has a code of `UNAUTHORIZED`

## Tests

- [x] Navigating to `dashboard` without logging in succesfully redirects me to `sign-in`
- [x] Navigating to `sign-in` whilst authed redirects me to either `callbackUrl` or `dashboard`
- [x] `ErrorBoundary` fallback component renders on different TRPCError codes
- [ ] `Suspense` fallback renders when data is suspending

