### PR TITLE
fix: add setup:test script for cicd to avoid migration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Start test containers
-        run: npm run setup
+        run: npm run setup:test
 
       - name: Build and test
         run: npm run build && npm run test-start && npm run test-dev

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "db:seed": "prisma db seed",
     "db:reset": "prisma migrate reset",
     "setup": "run-s --print-label db:setup db:sleep migrate:dev db:seed",
+    "setup:test": "run-s --print-label db:setup db:sleep generate db:seed",
     "teardown": "docker compose down",
     "dev": "next dev",
     "prebuild": "run-s generate migrate",


### PR DESCRIPTION
e2e tests failed previously. now they do not. 