### PR TITLE
fix: add starting slash to sign in redirect

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -50,8 +50,8 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
         const callbackUrl = params.get('callbackUrl')
 
         window.location.href = !!callbackUrl
-          ? `sign-in/?${CALLBACK_URL_KEY}=${callbackUrl}`
-          : `sign-in`
+          ? `/sign-in/?${CALLBACK_URL_KEY}=${callbackUrl}`
+          : `/sign-in`
 
         return
       }


### PR DESCRIPTION
## Problem

sign in needs a forward slash so the route replaces the entire route instead of being appended to the current path

**Example**
If you try to navigate to `/post/[id]` while unauthenticated, you will be rerouted to `/post/sign-in`

## Solution

- Append forward slash to start of route