### PR TITLE
fix: remove duplicate prettier config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,15 +39,7 @@ const config = {
         ],
       },
     ],
-    'prettier/prettier': [
-      'error',
-      {
-        trailingComma: 'es5',
-        tabWidth: 2,
-        semi: false,
-        singleQuote: true,
-      },
-    ],
+    'prettier/prettier': 'error',
     '@typescript-eslint/no-unused-vars': [
       'error',
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },

--- a/package.json
+++ b/package.json
@@ -30,9 +30,8 @@
     "seed": "tsx prisma/seed.ts"
   },
   "prettier": {
-    "printWidth": 80,
-    "trailingComma": "all",
-    "singleQuote": true
+    "singleQuote": true,
+    "semi": false
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.305.0",


### PR DESCRIPTION
## Problem

We have two sets of Prettier configs:  

1. `package.json` - Prettier (and its VSCode extension) reads this
2. `.eslintrc.cjs` - ESLint reads this, but [will default to `package.json` if not explicitly configured](https://github.com/prettier/eslint-plugin-prettier#recommended-configuration)

This causes code formatted by the extension to conflict with the linter. 

## Solution

- Remove the one in `.eslintrc.cjs`, all tools should rely on the config in `package.json` for consistency
- Found some unnecessary rules that are identical to Prettier's defaults, removed them
