### PR TITLE
fix: make sgid truly optional

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -58,6 +58,7 @@ const sgidServerSchema = z.discriminatedUnion('NEXT_PUBLIC_ENABLE_SGID', [
     SGID_CLIENT_ID: z.string().min(1),
     SGID_CLIENT_SECRET: z.string().min(1),
     SGID_PRIVATE_KEY: z.string().min(1),
+    SGID_REDIRECT_URI: z.string().url(),
   }),
   baseSgidSchema.extend({
     NEXT_PUBLIC_ENABLE_SGID: z.literal(false),

--- a/src/lib/sgid.ts
+++ b/src/lib/sgid.ts
@@ -1,13 +1,14 @@
 import SgidClient, { type SgidClientParams } from '@opengovsg/sgid-client'
 import { env } from '~/env.mjs'
-import { getBaseUrl } from '~/utils/getBaseUrl'
 
 const sgidOptions = {
   clientId: env.SGID_CLIENT_ID,
   clientSecret: env.SGID_CLIENT_SECRET,
   privateKey: env.SGID_PRIVATE_KEY,
   // Client requires at least a default uri to be registered
-  redirectUri: env.SGID_REDIRECT_URI ?? `${getBaseUrl()}/sign-in/sgid/callback`,
+  redirectUri: env.SGID_REDIRECT_URI,
 } as SgidClientParams
 
-export const sgid = new SgidClient(sgidOptions)
+export const sgid = env.NEXT_PUBLIC_ENABLE_SGID
+  ? new SgidClient(sgidOptions)
+  : null

--- a/src/server/modules/auth/sgid/sgid.router.ts
+++ b/src/server/modules/auth/sgid/sgid.router.ts
@@ -34,7 +34,7 @@ export const sgidRouter = router({
       })
     )
     .mutation(async ({ ctx, input: { landingUrl } }) => {
-      if (!env.NEXT_PUBLIC_ENABLE_SGID) {
+      if (!sgid) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'SGID is not enabled',

--- a/src/server/modules/auth/sgid/sgid.utils.ts
+++ b/src/server/modules/auth/sgid/sgid.utils.ts
@@ -19,6 +19,10 @@ export const getUserInfo = async ({
   codeVerifier: string
   nonce?: string
 }) => {
+  if (!sgid) {
+    throw new Error('SGID is not enabled')
+  }
+
   const { sub, accessToken } = await sgid.callback({
     code,
     nonce,


### PR DESCRIPTION
Currently, the sgid client initialisation will be invoked even if the environment variables are not set, resulting in an error. This commit correctly initiates the sgid client only if the enable flag is true
