### PR TITLE
fix: error boundary fall back and signout catch all

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -9,6 +9,16 @@ import { TRPCWithErrorCodeSchema } from '../../utils/error'
 import { UnexpectedErrorCard } from './UnexpectedErrorCard'
 import { CALLBACK_URL_KEY } from '~/constants/params'
 
+/**
+ * Does the following:
+ * 1. Checks if this is a recognizable TRPCClientError
+ * 1a. Not a TRPCClientError
+ *     - Render fallback component or UnexpectedErrorCard
+ * 1b. Is a TPRCClientError
+ *     - Checks if its an UNAUTHORIZED error
+ * 2a. Is an UNAUTHORIZED error, redirect to `/sign-in` page
+ * 2b. Not a UNAUTHORIZED error, render fallback component or <ErrorComponent /> according to switch case error code
+ */
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props)
@@ -30,9 +40,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     const error = this.state.error
 
     // Check if the error is thrown
-    if (!this.state.hasError) {
-      return children
-    }
+    if (!this.state.hasError) return children
 
     const res = TRPCWithErrorCodeSchema.safeParse(error)
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@chakra-ui/react'
-import { TRPCClientError } from '@trpc/client'
 import { type TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc'
 import { Component } from 'react'
 import {
@@ -35,32 +34,26 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       return children
     }
 
-    if (fallback !== undefined) {
-      return fallback
+    const res = TRPCWithErrorCodeSchema.safeParse(error)
+
+    if (!res.success) return !!fallback ? fallback : <UnexpectedErrorCard />
+
+    // The choice to not redirect via next's router was intentional to handle ErrorBoundary for the app root
+    // Using next's router.push('/sign-in') will not render the SignIn component as it won't be mounted in the app root as the ErrorBoundary fallback component will be rendered instead
+    // Using vanilla location redirecting will prompt a full page reload of /sign-in page, which will never trigger the root ErrorBoundary, thus rendering the full component correctly
+    if (res.data === 'UNAUTHORIZED') {
+      const params = new URLSearchParams(window.location.search)
+
+      const callbackUrl = params.get('callbackUrl')
+
+      window.location.href = !!callbackUrl
+        ? `/sign-in/?${CALLBACK_URL_KEY}=${callbackUrl}`
+        : `/sign-in`
+
+      return
     }
 
-    if (error instanceof TRPCClientError) {
-      const res = TRPCWithErrorCodeSchema.safeParse(error)
-
-      if (!res.success) return <UnexpectedErrorCard />
-
-      // The choice to not redirect via next's router was intentional to handle ErrorBoundary for the app root
-      // Using next's router.push('/sign-in') will not render the SignIn component as it won't be mounted in the app root as the ErrorBoundary fallback component will be rendered instead
-      // Using vanilla location redirecting will prompt a full page reload of /sign-in page, which will never trigger the root ErrorBoundary, thus rendering the full component correctly
-      if (res.data === 'UNAUTHORIZED') {
-        const params = new URLSearchParams(window.location.search)
-
-        const callbackUrl = params.get('callbackUrl')
-
-        window.location.href = !!callbackUrl
-          ? `/sign-in/?${CALLBACK_URL_KEY}=${callbackUrl}`
-          : `/sign-in`
-
-        return
-      }
-
-      return <ErrorComponent code={res.data} />
-    }
+    return !!fallback ? fallback : <ErrorComponent code={res.data} />
   }
 }
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -44,7 +44,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
     const res = TRPCWithErrorCodeSchema.safeParse(error)
 
-    if (!res.success) return !!fallback ? fallback : <UnexpectedErrorCard />
+    if (!res.success) return fallback ?? <UnexpectedErrorCard />
 
     // The choice to not redirect via next's router was intentional to handle ErrorBoundary for the app root
     // Using next's router.push('/sign-in') will not render the SignIn component as it won't be mounted in the app root as the ErrorBoundary fallback component will be rendered instead
@@ -61,7 +61,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       return
     }
 
-    return !!fallback ? fallback : <ErrorComponent code={res.data} />
+    return fallback ?? <ErrorComponent code={res.data} />
   }
 }
 

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -14,11 +14,11 @@ export default trpcNext.createNextApiHandler({
   /**
    * @link https://trpc.io/docs/error-handling
    */
-  // onError({ error }) {
-  //   if (error.code === 'INTERNAL_SERVER_ERROR') {
-  //     // send to bug reporting
-  //   }
-  // },
+  onError({ error, ctx }) {
+    if (error.code === 'UNAUTHORIZED') {
+      ctx?.session?.destroy()
+    }
+  },
   /**
    * Enable query batching
    */

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -69,8 +69,6 @@ const authMiddleware = t.middleware(async ({ next, ctx }) => {
   })
 
   if (user === null) {
-    ctx.session.destroy()
-
     throw new TRPCError({ code: 'UNAUTHORIZED' })
   }
 


### PR DESCRIPTION
- fixes error boundary not having a default unexpected error card which gets returned
- switched sequence of conditional statements, previously we could render `fallback` child even if unauthorized error was thrown, but a better flow would be to always just redirect to `/sign-in` page if `UNAUTHORIZED` was thrown
- whenever an `UNAUTHORIZED` error was thrown, destroy session in backend so user will be logged out. 
    - there was a scenario where infinite redirects could happen if the session was not destroyed (this can happen when someone throws an `UNAUTHORIZED` error without ctx.session.destroy()