### PR TITLE
chore(ci): make dependabot ignore storybook packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 2
+    ignore:
+      # Storybook packages should be updated together to avoid breaking changes, but dependabot updates them separately.
+      - dependency-name: 'storybook*'
+      - dependency-name: '@storybook*'


### PR DESCRIPTION
Storybook packages should be updated together to avoid breaking changes, but dependabot updates them separately.
