### PR TITLE
chore: add extra log properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39902,6 +39902,13 @@
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+        }
       }
     },
     "postcss-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "iron-session": "^6.3.1",
         "jotai": "^2.2.0",
         "lodash": "^4.17.21",
+        "nanoid": "^4.0.2",
         "next": "^13.4.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -6258,6 +6259,23 @@
         "react-dom": "^18.2.0"
       }
     },
+    "node_modules/@opengovsg/design-system-react/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/@opengovsg/sgid-client": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opengovsg/sgid-client/-/sgid-client-2.0.0.tgz",
@@ -8298,6 +8316,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/@storybook/nextjs/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/@storybook/nextjs/node_modules/postcss": {
       "version": "8.4.24",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
@@ -8615,6 +8651,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/@storybook/testing-library": {
@@ -12712,6 +12766,24 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/css-loader/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/css-loader/node_modules/postcss": {
@@ -18896,9 +18968,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
       "funding": [
         {
           "type": "github",
@@ -18906,10 +18978,10 @@
         }
       ],
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/natural-compare": {
@@ -20268,6 +20340,23 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -23991,6 +24080,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/vite/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/vite/node_modules/postcss": {
@@ -29364,6 +29471,13 @@
         "react-virtuoso": "^4.0.1",
         "rooks": "^7.4.2",
         "use-draggable-scroll": "^0.1.0"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+        }
       }
     },
     "@opengovsg/sgid-client": {
@@ -30852,6 +30966,12 @@
           "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
           "dev": true
         },
+        "nanoid": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+          "dev": true
+        },
         "postcss": {
           "version": "8.4.24",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
@@ -31067,6 +31187,14 @@
         "isomorphic-unfetch": "^3.1.0",
         "nanoid": "^3.3.1",
         "read-pkg-up": "^7.0.1"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+          "dev": true
+        }
       }
     },
     "@storybook/testing-library": {
@@ -34259,6 +34387,12 @@
         "semver": "^7.3.8"
       },
       "dependencies": {
+        "nanoid": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+          "dev": true
+        },
         "postcss": {
           "version": "8.4.24",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
@@ -38969,9 +39103,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -42773,6 +42907,12 @@
         "rollup": "^3.21.0"
       },
       "dependencies": {
+        "nanoid": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+          "dev": true
+        },
         "postcss": {
           "version": "8.4.24",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "jotai": "^2.2.0",
     "lodash": "^4.17.21",
     "next": "^13.4.6",
+    "nanoid": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.5",

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,9 +1,15 @@
+import { nanoid } from 'nanoid'
 import winston, { format } from 'winston'
 import { env } from '~/env.mjs'
 
 const { combine, timestamp, prettyPrint, colorize } = format
 
-export const createBaseLogger = (path: string) => {
+type LoggerOptions = {
+  path: string
+  clientIp?: string
+}
+
+export const createBaseLogger = ({ path, clientIp }: LoggerOptions) => {
   const formats = [
     winston.format.json(),
     timestamp(),
@@ -21,6 +27,8 @@ export const createBaseLogger = (path: string) => {
     ],
     defaultMeta: {
       path,
+      clientIp,
+      id: nanoid(),
     },
   })
 }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -26,9 +26,14 @@ export async function createContextInner(opts: CreateContextOptions) {
 export const createContext = async (opts: CreateNextContextOptions) => {
   const session = await getIronSession(opts.req, opts.res, sessionOptions)
 
-  return await createContextInner({
+  const innerContext = await createContextInner({
     session,
   })
+
+  return {
+    ...innerContext,
+    req: opts.req,
+  }
 }
 
-export type Context = trpc.inferAsyncReturnType<typeof createContextInner>
+export type Context = trpc.inferAsyncReturnType<typeof createContext>

--- a/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -1,8 +1,10 @@
-import { applySession } from 'tests/integration/helpers/iron-session'
+import {
+  applySession,
+  createMockRequest,
+} from 'tests/integration/helpers/iron-session'
 import { it, expect, describe } from 'vitest'
 import { env } from '~/env.mjs'
 import * as mailLib from '~/lib/mail'
-import { createContextInner } from '~/server/context'
 import { prisma } from '~/server/prisma'
 import { createTokenHash } from '../../auth.util'
 import { emailSessionRouter } from '../email.router'
@@ -12,8 +14,7 @@ describe('auth.email', async () => {
   let session: ReturnType<typeof applySession>
 
   beforeEach(async () => {
-    session = applySession()
-    const ctx = await createContextInner({ session })
+    const ctx = await createMockRequest(applySession(), { headers: {} })
     caller = emailSessionRouter.createCaller(ctx)
   })
 

--- a/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -14,7 +14,8 @@ describe('auth.email', async () => {
   let session: ReturnType<typeof applySession>
 
   beforeEach(async () => {
-    const ctx = await createMockRequest(applySession(), { headers: {} })
+    session = applySession()
+    const ctx = await createMockRequest(session)
     caller = emailSessionRouter.createCaller(ctx)
   })
 

--- a/src/server/modules/post/__tests__/post.router.test.ts
+++ b/src/server/modules/post/__tests__/post.router.test.ts
@@ -1,17 +1,16 @@
 import { type User } from '@prisma/client'
 import { it, expect } from 'vitest'
-import { createContextInner } from '~/server/context'
 import { type RouterInput } from '~/utils/trpc'
 import { appRouter } from '../../_app'
 import {
   applyAuthedSession,
   applySession,
+  createMockRequest,
 } from 'tests/integration/helpers/iron-session'
 
 describe('post.add', async () => {
   it('unauthed user should not be able to create a post', async () => {
-    const session = applySession()
-    const ctx = await createContextInner({ session })
+    const ctx = await createMockRequest(applySession(), { headers: {} })
     const caller = appRouter.createCaller(ctx)
 
     const input: RouterInput['post']['add'] = {
@@ -32,10 +31,7 @@ describe('post.add', async () => {
       emailVerified: null,
       image: null,
     }
-    const session = await applyAuthedSession(defaultUser)
-    const ctx = await createContextInner({
-      session,
-    })
+    const ctx = await createMockRequest(await applyAuthedSession(defaultUser))
     const caller = appRouter.createCaller(ctx)
 
     const input: RouterInput['post']['add'] = {

--- a/src/server/modules/post/__tests__/post.router.test.ts
+++ b/src/server/modules/post/__tests__/post.router.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe('post.add', async () => {
   it('unauthed user should not be able to create a post', async () => {
-    const ctx = await createMockRequest(applySession(), { headers: {} })
+    const ctx = await createMockRequest(applySession())
     const caller = appRouter.createCaller(ctx)
 
     const input: RouterInput['post']['add'] = {

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -14,6 +14,7 @@ import { type Context } from './context'
 import { TRPCError, initTRPC } from '@trpc/server'
 import { prisma } from './prisma'
 import { createBaseLogger } from '~/lib/logger'
+import getIP from '~/utils/getClientIp'
 
 const t = initTRPC.context<Context>().create({
   /**
@@ -39,9 +40,9 @@ const t = initTRPC.context<Context>().create({
 
 // Setting outer context with TPRC will not get us correct path during request batching, only by setting logger context in
 // the middleware do we get the exact path to log
-const loggerMiddleware = t.middleware(async ({ path, next }) => {
+const loggerMiddleware = t.middleware(async ({ path, next, ctx }) => {
   const start = Date.now()
-  const logger = createBaseLogger(path)
+  const logger = createBaseLogger({ path, clientIp: getIP(ctx.req) })
 
   const result = await next({
     ctx: { logger },

--- a/src/utils/getClientIp.ts
+++ b/src/utils/getClientIp.ts
@@ -1,0 +1,10 @@
+import { type NextApiRequest } from 'next'
+
+export default function getIP(request: Request | NextApiRequest) {
+  const xff =
+    request instanceof Request
+      ? request.headers.get('x-forwarded-for')
+      : request.headers['x-forwarded-for']
+
+  return xff ? (Array.isArray(xff) ? xff[0] : xff.split(',')[0]) : '127.0.0.1'
+}

--- a/tests/integration/helpers/iron-session.ts
+++ b/tests/integration/helpers/iron-session.ts
@@ -1,5 +1,7 @@
 import { type User } from '@prisma/client'
 import { type IronSession } from 'iron-session'
+import { type NextApiRequest } from 'next'
+import { type Context, createContextInner } from '~/server/context'
 import { auth } from './auth'
 
 class MockIronStore {
@@ -39,6 +41,18 @@ class MockIronStore {
 
   clear() {
     this.unsaved = {}
+  }
+}
+
+export const createMockRequest = async (
+  session: IronSession,
+  mockedReq: Partial<NextApiRequest> = { headers: {} }
+): Promise<Context> => {
+  const innerContext = await createContextInner({ session })
+
+  return {
+    ...innerContext,
+    req: mockedReq as NextApiRequest,
   }
 }
 


### PR DESCRIPTION
Adds extra properties to logger context for better observability

- `id`: for better traces across log invocations
- `clientIp`: to track ip of client - helpful during instances where you need to block ip addresses in case of bots