### PR TITLE
fix: allow empty string in SENDGRID_FROM_ADDRESS env var validation

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -76,7 +76,10 @@ const server = z
     OTP_EXPIRY: z.coerce.number().positive().optional().default(600),
     POSTMAN_API_KEY: z.string().optional(),
     SENDGRID_API_KEY: z.string().optional(),
-    SENDGRID_FROM_ADDRESS: z.string().email().optional(),
+    SENDGRID_FROM_ADDRESS: z.union([
+      z.string().email().optional(),
+      z.string().length(0),
+    ]),
     SESSION_SECRET: z.string().min(32),
   })
   // Add on schemas as needed that requires conditional validation.

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -36,7 +36,7 @@ export const sendMail = async (params: SendMailParams): Promise<void> => {
   }
 
   console.warn(
-    'POSTMAN_API_KEY or POSTMARK_API_TOKEN missing. Logging the following mail: ',
+    'POSTMAN_API_KEY or SENDGRID_API_KEY missing. Logging the following mail: ',
     params
   )
   return


### PR DESCRIPTION
This PR fixes the bug where validation will fail if Sendgrid SENDGRID_FROM_ADDRESS is not provided. 

Also updates the logging message when neither Postman nor Sendgrid environment variables are provided, to change from the help text referencing Postmark to Sendgrid