### PR TITLE
ci: fix missing db migration in setup:test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+
       - name: Start test containers
         run: npm run setup:test
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "db:seed": "prisma db seed",
     "db:reset": "prisma migrate reset",
     "setup": "run-s --print-label db:setup db:sleep migrate:dev db:seed",
-    "setup:test": "run-s --print-label db:setup db:sleep generate db:seed",
+    "setup:test": "run-s --print-label db:setup db:sleep migrate db:seed",
     "teardown": "docker compose down",
     "dev": "next dev",
     "prebuild": "run-s generate migrate",


### PR DESCRIPTION
## Problem

CI tests will fail when `seed.ts` is not empty.

This occurs because the current `setup:test` step does not perform migrations, resulting in any seed operations to fail.

Currently, the CI stage passes because there are no operations performed in `seed.ts` and so this error does not occur.

## Solution

Replace the `prisma generate` command in `setup:test` with `prisma migrate deploy`.

We opt to use `prisma migrate deploy` in favour of `prisma migrate dev` as the latter will attempt to create a migration for any pending changes in the schema.

The `prisma generate` step is removed as it is performed in the `postinstall` step.