### PR TITLE
fix: allow insecure connections during development

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,7 @@ const ContentSecurityPolicy = `
   };
   frame-src 'self';
   object-src 'none';
-  script-src 'self' ${env.NODE_ENV === 'development' ? "'unsafe-eval'" : ''};
+  script-src 'self' ${env.NODE_ENV === 'production' ? '' : "'unsafe-eval'"};
   style-src 'self' https: 'unsafe-inline';
   connect-src 'self' https://*.browser-intake-datadoghq.com https://vitals.vercel-insights.com/v1/vitals ${
     // For POSTing presigned URLs to R2 storage.
@@ -25,7 +25,7 @@ const ContentSecurityPolicy = `
       : ''
   };
   worker-src 'self' blob:;
-  upgrade-insecure-requests
+  ${env.NODE_ENV === 'production' ? 'upgrade-insecure-requests' : ''}'
 `
 
 /**

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,4 +7,7 @@ export const sessionOptions: IronSessionOptions = {
   },
   cookieName: 'auth.session-token',
   ttl: 60 * 60 * 24 * 7, // 7 days
+  cookieOptions: {
+    secure: env.NODE_ENV === 'production',
+  },
 }


### PR DESCRIPTION
## Problem

1. The webpage does not load during development in Safari. 
2. Login does not work on Safari during development.

### Triage

The `upgrade-insecure-connections` header is set during development. This causes Safari to use `https` when retrieving other assets hosted on localhost.

The session cookie is not set upon successful login.
Safari does not accept cookies that have  `secure: true` flag that have been sent over an unsecure (`http`) connection.

## Solution

Unset the `upgrade-insecure-connections` header in non-production environments.
Unset the `secure` flag on the session cookie in non-production environments.