### PR TITLE
fix: make empty post list component span grid

### DIFF
--- a/src/features/home/components/EmptyPostList.tsx
+++ b/src/features/home/components/EmptyPostList.tsx
@@ -1,9 +1,10 @@
 import { Stack, Text } from '@chakra-ui/react'
 import { BusStop } from '~/components/Svg'
+import { APP_GRID_COLUMN } from '~/constants/layouts'
 
 export const EmptyPostList = (): JSX.Element => {
   return (
-    <Stack spacing="2rem" align="center" pt="3rem">
+    <Stack spacing="2rem" align="center" pt="3rem" gridColumn={APP_GRID_COLUMN}>
       <Text textStyle="subhead-2">There aren&apos;t any posts yet</Text>
       <BusStop />
     </Stack>


### PR DESCRIPTION
### Before
<img width="1226" alt="Screenshot 2023-08-04 at 2 02 34 PM" src="https://github.com/opengovsg/starter-kit/assets/22133008/08b48cf1-b9e0-4278-98cf-dbf286479a61">

### After
<img width="1226" alt="image" src="https://github.com/opengovsg/starter-kit/assets/22133008/b885e5e5-c815-44c4-b99a-2d89a4c079a7">
