### PR TITLE
feat: make email address log in validation case insensitive

### DIFF
--- a/src/features/sign-in/components/Emailnput.tsx
+++ b/src/features/sign-in/components/Emailnput.tsx
@@ -15,6 +15,7 @@ export const emailSignInSchema = z.object({
   email: z
     .string()
     .trim()
+    .toLowerCase()
     .min(1, 'Please enter an email address.')
     .email({ message: 'Please enter a valid email address.' }),
 })

--- a/src/server/modules/auth/email/email.router.ts
+++ b/src/server/modules/auth/email/email.router.ts
@@ -17,7 +17,7 @@ export const emailSessionRouter = router({
   login: publicProcedure
     .input(
       z.object({
-        email: z.string().email(),
+        email: z.string().trim().toLowerCase().email(),
       })
     )
     .mutation(async ({ ctx, input: { email } }) => {


### PR DESCRIPTION
## Problem

Email addresses for user accounts are treated case sensitive.
This means that email@example.com will create a different user account than Email@example.com.

## Solution

- Treat all email address input as lowercased on sign in (front end & backend)
