### PR TITLE
fix: reset timer on resend otp, replace rooks with usehooks-ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.45.2",
         "react-icons": "^4.8.0",
-        "rooks": "^7.11.2",
         "superjson": "^1.12.3",
         "usehooks-ts": "^2.9.1",
         "validator": "^13.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "react-icons": "^4.8.0",
         "rooks": "^7.11.2",
         "superjson": "^1.12.3",
+        "usehooks-ts": "^2.9.1",
         "validator": "^13.9.0",
         "winston": "^3.9.0",
         "wretch": "^2.6.0",
@@ -24041,6 +24042,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/usehooks-ts": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
+      "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
+      "engines": {
+        "node": ">=16.15.0",
+        "npm": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -43001,6 +43015,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
+    },
+    "usehooks-ts": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
+      "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
       "requires": {}
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.2",
     "react-icons": "^4.8.0",
-    "rooks": "^7.11.2",
     "superjson": "^1.12.3",
     "usehooks-ts": "^2.9.1",
     "validator": "^13.9.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "react-icons": "^4.8.0",
     "rooks": "^7.11.2",
     "superjson": "^1.12.3",
+    "usehooks-ts": "^2.9.1",
     "validator": "^13.9.0",
     "winston": "^3.9.0",
     "wretch": "^2.6.0",

--- a/src/features/sign-in/components/SignInContext.tsx
+++ b/src/features/sign-in/components/SignInContext.tsx
@@ -14,6 +14,7 @@ type SignInStates = {
   setEmail: Dispatch<SetStateAction<string>>
   showVerificationStep: boolean
   setShowVerificationStep: Dispatch<SetStateAction<boolean>>
+  delayForResendSeconds: number
 }
 
 export const SignInContext = createContext<SignInStates | undefined>(undefined)
@@ -30,12 +31,21 @@ export const useSignInContext = () => {
   return context
 }
 
-export const SignInContextProvider: React.FC<PropsWithChildren> = ({
+interface SignInContextProviderProps {
+  /**
+   * The number of seconds to wait before allowing the user to resend the OTP.
+   * @default 60
+   */
+  delayForResendSeconds?: number
+}
+
+export const SignInContextProvider = ({
   children,
-}) => {
+  delayForResendSeconds = 60,
+}: PropsWithChildren<SignInContextProviderProps>) => {
   const [email, setEmail] = useState('')
   const [showVerificationStep, setShowVerificationStep] = useState(false)
-  const [timer, setTimer] = useState(60)
+  const [timer, setTimer] = useState(delayForResendSeconds)
 
   return (
     <SignInContext.Provider
@@ -46,6 +56,7 @@ export const SignInContextProvider: React.FC<PropsWithChildren> = ({
         setShowVerificationStep,
         timer,
         setTimer,
+        delayForResendSeconds,
       }}
     >
       {children}

--- a/src/features/sign-in/components/VerificationInput.tsx
+++ b/src/features/sign-in/components/VerificationInput.tsx
@@ -1,7 +1,7 @@
 import { FormControl, FormLabel, Stack } from '@chakra-ui/react'
 import { Button, FormErrorMessage, Input } from '@opengovsg/design-system-react'
 import { useRouter } from 'next/router'
-import { useIntervalWhen } from 'rooks'
+import { useInterval } from 'usehooks-ts'
 import { z } from 'zod'
 import { CALLBACK_URL_KEY } from '~/constants/params'
 import { useZodForm } from '~/lib/form'
@@ -24,11 +24,10 @@ export const VerificationInput = (): JSX.Element => {
 
   const { email, timer, setTimer } = useSignInContext()
 
-  useIntervalWhen(
+  useInterval(
     () => setTimer(timer - 1),
-    /* intervalDurationMs= */ 1000,
-    // Stop interval if timer hits 0.
-    /* when= */ timer > 0
+    // Stop interval if timer hits 0, else rerun every 1000ms.
+    timer > 0 ? 1000 : null
   )
 
   const {

--- a/src/features/sign-in/components/VerificationInput.tsx
+++ b/src/features/sign-in/components/VerificationInput.tsx
@@ -22,7 +22,7 @@ const emailVerificationSchema = emailSignInSchema.extend({
 export const VerificationInput = (): JSX.Element => {
   const router = useRouter()
 
-  const { email, timer, setTimer } = useSignInContext()
+  const { email, timer, setTimer, delayForResendSeconds } = useSignInContext()
 
   useInterval(
     () => setTimer(timer - 1),
@@ -68,7 +68,11 @@ export const VerificationInput = (): JSX.Element => {
 
   const handleResendOtp = () => {
     if (timer > 0) return
-    return resendOtpMutation.mutate({ email })
+    return resendOtpMutation.mutate(
+      { email },
+      // On success, restart the timer before this can be called again.
+      { onSuccess: () => setTimer(delayForResendSeconds) }
+    )
   }
 
   return (


### PR DESCRIPTION
Currently users are able to resend OTP infinite times. This PR blocks the frontend from resending OTP for 60 seconds correctly.

Also replaces `rooks` package with `usehooks-ts` package, since the hooks in `usehooks-ts` has better support for SSR