### PR TITLE
fix(openapi): send spec with `.json()`, use cookie auth

### DIFF
--- a/src/pages/api/openapi.json.ts
+++ b/src/pages/api/openapi.json.ts
@@ -4,7 +4,7 @@ import { openApiDocument } from '../../server/openapi'
 
 // Respond with our OpenAPI schema
 const handler = (_req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).send(openApiDocument)
+  res.status(200).json(openApiDocument)
 }
 
 export default handler

--- a/src/server/openapi.ts
+++ b/src/server/openapi.ts
@@ -1,9 +1,17 @@
 import { generateOpenApiDocument } from 'trpc-openapi'
 import { appRouter } from './modules/_app'
 import { getBaseUrl } from '~/utils/getBaseUrl'
+import { sessionOptions } from '~/lib/auth'
 
 export const openApiDocument = generateOpenApiDocument(appRouter, {
   title: 'Starter Kit OpenAPI',
   version: '1.0.0',
   baseUrl: `${getBaseUrl()}/api`,
+  securitySchemes: {
+    cookieAuth: {
+      type: 'apiKey',
+      in: 'cookie',
+      name: sessionOptions.cookieName,
+    },
+  },
 })


### PR DESCRIPTION
- Correct OpenAPI spec to state the use of cookies for auth
- Use `json()`, not `send()`, to ensure spec is only sent as JSON