### PR TITLE
fix(sidebar): ensure no display when hidden

### DIFF
--- a/src/components/DashSidebar.tsx
+++ b/src/components/DashSidebar.tsx
@@ -103,6 +103,10 @@ export const DashSidebar = () => {
             px={{ base: '1.125rem', sm: '0.75rem', md: '1rem' }}
             borderRadius={{ base: 0, md: 'md' }}
             onClick={() => setShowWhenSmallMobile(false)}
+            display={{
+              base: showWhenSmallMobile ? 'flex' : 'none',
+              sm: 'flex',
+            }}
           >
             {showText ? '' : 'Home'}
           </SidebarItem>
@@ -115,6 +119,10 @@ export const DashSidebar = () => {
             px={{ base: '1.125rem', sm: '0.75rem', md: '1rem' }}
             borderRadius={{ base: 0, md: 'md' }}
             onClick={() => setShowWhenSmallMobile(false)}
+            display={{
+              base: showWhenSmallMobile ? 'flex' : 'none',
+              sm: 'flex',
+            }}
           >
             {showText ? '' : 'Profile'}
           </SidebarItem>


### PR DESCRIPTION
## Problem

When hidden, the user can still interact with the sidebar items if they click at the right spot

## Solution

Set `display: none` on sidebar items if `showWhenSmallMobile` is false