### PR TITLE
feat(trpc): use fetch fn that directs to window.fetch

### DIFF
--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -111,6 +111,14 @@ export const trpc = createTRPCNext<
         httpBatchLink({
           url: `${getBaseUrl()}/api/trpc`,
           /**
+           * Provide a function that will invoke the current global
+           * window.fetch. We do this to pick up any changes to fetch
+           * at runtime, eg, by Datadog RUM
+           */
+          fetch(url, options) {
+            return fetch(url, options)
+          },
+          /**
            * Set custom request headers on every request from tRPC
            * @link https://trpc.io/docs/ssr
            */


### PR DESCRIPTION
## Problem

By default, tRPC will retain its own reference to window.fetch on init. Any changes to or replacements of window.fetch would not be picked up by tRPC, which will affect eg, instrumentation by Datadog RUM.

## Solution

Fix this by supplying our own fetch implementation that delegates to whatever is the current global `fetch()`.
