### PR TITLE
fix: use transaction in a transaction

### DIFF
--- a/src/server/modules/auth/sgid/sgid.service.ts
+++ b/src/server/modules/auth/sgid/sgid.service.ts
@@ -43,7 +43,7 @@ export const upsertSgidAccountAndUser = async ({
       sub,
       pocdexEmail,
     )
-    await prisma.accounts.upsert({
+    await tx.accounts.upsert({
       where: {
         provider_providerAccountId: {
           provider: AccountProvider.SgidPocdex,


### PR DESCRIPTION
This PR fixes a bug where account creation may fail due to not having the user created prior to linking. This happened because the user was created in a transaction but the account was created without using the transaction connection inside the transaction.
