### PR TITLE
fix: only allow relative paths for callback URL query param

### DIFF
--- a/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
+++ b/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router'
 import { useMemo, type PropsWithChildren } from 'react'
-import { CALLBACK_URL_KEY } from '~/constants/params'
 import { useLoginState } from '~/features/auth'
 import { SIGN_IN } from '~/lib/routes'
 import { FullscreenSpinner } from '../FullscreenSpinner'

--- a/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
+++ b/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
@@ -4,6 +4,7 @@ import { CALLBACK_URL_KEY } from '~/constants/params'
 import { useLoginState } from '~/features/auth'
 import { SIGN_IN } from '~/lib/routes'
 import { FullscreenSpinner } from '../FullscreenSpinner'
+import { appendWithRedirect } from '~/utils/url'
 
 interface EnforceLoginStatePageWrapperProps {
   /**
@@ -21,7 +22,7 @@ const Redirect = ({ redirectTo }: EnforceLoginStatePageWrapperProps) => {
     return encodeURIComponent(`${pathname}${search}${hash}`)
   }, [])
 
-  void router.replace(`${redirectTo}?${CALLBACK_URL_KEY}=${redirectUrl}`)
+  void router.replace(appendWithRedirect(redirectTo ?? SIGN_IN, redirectUrl))
 
   return <FullscreenSpinner />
 }

--- a/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
+++ b/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
@@ -4,6 +4,7 @@ import { useLoginState } from '~/features/auth'
 import { SIGN_IN } from '~/lib/routes'
 import { FullscreenSpinner } from '../FullscreenSpinner'
 import { appendWithRedirect } from '~/utils/url'
+import { callbackUrlSchema } from '~/schemas/url'
 
 interface EnforceLoginStatePageWrapperProps {
   /**
@@ -21,7 +22,11 @@ const Redirect = ({ redirectTo }: EnforceLoginStatePageWrapperProps) => {
     return encodeURIComponent(`${pathname}${search}${hash}`)
   }, [])
 
-  void router.replace(appendWithRedirect(redirectTo ?? SIGN_IN, redirectUrl))
+  void router.replace(
+    callbackUrlSchema.parse(
+      appendWithRedirect(redirectTo ?? SIGN_IN, redirectUrl),
+    ),
+  )
 
   return <FullscreenSpinner />
 }

--- a/src/components/AuthWrappers/PublicPageWrapper.tsx
+++ b/src/components/AuthWrappers/PublicPageWrapper.tsx
@@ -2,9 +2,8 @@ import { useRouter } from 'next/router'
 import { type PropsWithChildren } from 'react'
 import { CALLBACK_URL_KEY } from '~/constants/params'
 import { useLoginState } from '~/features/auth'
-import { HOME } from '~/lib/routes'
+import { callbackUrlSchema } from '~/schemas/url'
 import { FullscreenSpinner } from '../FullscreenSpinner'
-import { isRelativeUrl } from '~/utils/url'
 
 type PublicPageWrapperProps =
   | { strict: true; redirectUrl?: string }
@@ -24,13 +23,13 @@ export const PublicPageWrapper = ({
   const { hasLoginStateFlag } = useLoginState()
 
   if (hasLoginStateFlag && rest.strict) {
-    const callbackParam = String(router.query[CALLBACK_URL_KEY])
-    const callbackUrl =
-      // redirectUrl is already checked as it is constructed using `appendWithRedirect`
-      rest.redirectUrl ?? (callbackParam && isRelativeUrl(callbackParam))
-        ? callbackParam
-        : HOME
-    void router.replace(callbackUrl)
+    if (rest.redirectUrl) {
+      void router.replace(callbackUrlSchema.parse(rest.redirectUrl))
+    } else {
+      void router.replace(
+        callbackUrlSchema.parse(router.query[CALLBACK_URL_KEY]),
+      )
+    }
     return <FullscreenSpinner />
   }
 

--- a/src/components/AuthWrappers/PublicPageWrapper.tsx
+++ b/src/components/AuthWrappers/PublicPageWrapper.tsx
@@ -4,6 +4,7 @@ import { CALLBACK_URL_KEY } from '~/constants/params'
 import { useLoginState } from '~/features/auth'
 import { HOME } from '~/lib/routes'
 import { FullscreenSpinner } from '../FullscreenSpinner'
+import { isRelativeUrl } from '~/utils/url'
 
 type PublicPageWrapperProps =
   | { strict: true; redirectUrl?: string }
@@ -23,8 +24,12 @@ export const PublicPageWrapper = ({
   const { hasLoginStateFlag } = useLoginState()
 
   if (hasLoginStateFlag && rest.strict) {
+    const callbackParam = String(router.query[CALLBACK_URL_KEY])
     const callbackUrl =
-      rest.redirectUrl ?? String(router.query[CALLBACK_URL_KEY] ?? HOME)
+      // redirectUrl is already checked as it is constructed using `appendWithRedirect`
+      rest.redirectUrl ?? (callbackParam && isRelativeUrl(callbackParam))
+        ? callbackParam
+        : HOME
     void router.replace(callbackUrl)
     return <FullscreenSpinner />
   }

--- a/src/features/sign-in/components/EmailLogin/VerificationInput.tsx
+++ b/src/features/sign-in/components/EmailLogin/VerificationInput.tsx
@@ -14,7 +14,6 @@ import {
 import { useRouter } from 'next/router'
 import { CALLBACK_URL_KEY } from '~/constants/params'
 import { useZodForm } from '~/lib/form'
-import { HOME } from '~/lib/routes'
 import { trpc } from '~/utils/trpc'
 import { useSignInContext } from '../SignInContext'
 import { ResendOtpButton } from './ResendOtpButton'
@@ -24,6 +23,7 @@ import { Controller } from 'react-hook-form'
 import { OTP_LENGTH } from '~/lib/auth'
 import { useInterval } from 'usehooks-ts'
 import { useState } from 'react'
+import { callbackUrlSchema } from '~/schemas/url'
 
 export const VerificationInput = (): JSX.Element | null => {
   const [showOtpDelayMessage, setShowOtpDelayMessage] = useState(false)
@@ -60,7 +60,7 @@ export const VerificationInput = (): JSX.Element | null => {
       await utils.me.get.invalidate()
       // accessing router.query values returns decoded URI params automatically,
       // so there's no need to call decodeURIComponent manually when accessing the callback url.
-      await router.push(String(router.query[CALLBACK_URL_KEY] ?? HOME))
+      await router.push(callbackUrlSchema.parse(router.query[CALLBACK_URL_KEY]))
     },
     onError: (error) => {
       switch (error.message) {

--- a/src/features/sign-in/components/SgidCallback.tsx
+++ b/src/features/sign-in/components/SgidCallback.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 
 import { FullscreenSpinner } from '~/components/FullscreenSpinner'
 import { useLoginState } from '~/features/auth'
+import { callbackUrlSchema } from '~/schemas/url'
 import { trpc } from '~/utils/trpc'
 
 /**
@@ -31,7 +32,7 @@ export const SgidCallback = (): JSX.Element => {
       utils.me.get.invalidate()
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    router.replace(redirectUrl)
+    router.replace(callbackUrlSchema.parse(redirectUrl))
   }, [
     redirectUrl,
     router,

--- a/src/features/sign-in/components/SgidProfileList/SgidProfileList.tsx
+++ b/src/features/sign-in/components/SgidProfileList/SgidProfileList.tsx
@@ -3,12 +3,12 @@ import { useRouter } from 'next/router'
 import { Divider, Stack } from '@chakra-ui/react'
 
 import { trpc } from '~/utils/trpc'
-import { HOME } from '~/lib/routes'
 import { SgidProfileItem } from './SgidProfileItem'
 import { SgidProfileListSkeleton } from './SgidProfileListSkeleton'
 import { useLoginState } from '~/features/auth'
 import { CALLBACK_URL_KEY } from '~/constants/params'
 import { withSuspense } from '~/hocs/withSuspense'
+import { callbackUrlSchema } from '~/schemas/url'
 
 const _SgidProfileList = (): JSX.Element => {
   const router = useRouter()
@@ -22,7 +22,9 @@ const _SgidProfileList = (): JSX.Element => {
     onSuccess: async () => {
       setHasLoginStateFlag()
       await utils.me.get.invalidate()
-      await router.replace(String(router.query[CALLBACK_URL_KEY] ?? HOME))
+      await router.replace(
+        callbackUrlSchema.parse(router.query[CALLBACK_URL_KEY]),
+      )
     },
   })
 

--- a/src/schemas/url.ts
+++ b/src/schemas/url.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+import { HOME } from '~/lib/routes'
+import { isRelativeUrl } from '~/utils/url'
+
+export const callbackUrlSchema = z
+  .string()
+  .optional()
+  .default(HOME)
+  .refine((url) => url && isRelativeUrl(url))
+  .catch(HOME)

--- a/src/server/modules/auth/sgid/sgid.router.ts
+++ b/src/server/modules/auth/sgid/sgid.router.ts
@@ -10,7 +10,7 @@ import { HOME, SIGN_IN, SIGN_IN_SELECT_PROFILE_SUBROUTE } from '~/lib/routes'
 import { APP_SGID_SCOPE, sgid } from '~/lib/sgid'
 import { publicProcedure, router } from '~/server/trpc'
 import { trpcAssert } from '~/utils/trpcAssert'
-import { appendWithRedirect } from '~/utils/url'
+import { appendWithRedirect, isRelativeUrl } from '~/utils/url'
 import { normaliseEmail, safeSchemaJsonParse } from '~/utils/zod'
 import { upsertSgidAccountAndUser } from './sgid.service'
 import {
@@ -28,7 +28,12 @@ export const sgidRouter = router({
   login: publicProcedure
     .input(
       z.object({
-        landingUrl: z.string().default(HOME),
+        landingUrl: z
+          .string()
+          .default(HOME)
+          .refine((url) => isRelativeUrl(url), {
+            message: 'Invalid landing URL',
+          }),
       }),
     )
     .mutation(async ({ ctx, input: { landingUrl } }) => {

--- a/src/server/modules/auth/sgid/sgid.router.ts
+++ b/src/server/modules/auth/sgid/sgid.router.ts
@@ -6,11 +6,13 @@ import { TRPCError } from '@trpc/server'
 import { set } from 'lodash'
 import { z } from 'zod'
 import { env } from '~/env.mjs'
-import { HOME, SIGN_IN, SIGN_IN_SELECT_PROFILE_SUBROUTE } from '~/lib/routes'
+import { SGID } from '~/lib/errors/auth.sgid'
+import { SIGN_IN, SIGN_IN_SELECT_PROFILE_SUBROUTE } from '~/lib/routes'
 import { APP_SGID_SCOPE, sgid } from '~/lib/sgid'
+import { callbackUrlSchema } from '~/schemas/url'
 import { publicProcedure, router } from '~/server/trpc'
 import { trpcAssert } from '~/utils/trpcAssert'
-import { appendWithRedirect, isRelativeUrl } from '~/utils/url'
+import { appendWithRedirect } from '~/utils/url'
 import { normaliseEmail, safeSchemaJsonParse } from '~/utils/zod'
 import { upsertSgidAccountAndUser } from './sgid.service'
 import {
@@ -18,7 +20,6 @@ import {
   sgidSessionProfileSchema,
   type SgidUserInfo,
 } from './sgid.utils'
-import { SGID } from '~/lib/errors/auth.sgid'
 
 const sgidCallbackStateSchema = z.object({
   landingUrl: z.string(),
@@ -28,12 +29,7 @@ export const sgidRouter = router({
   login: publicProcedure
     .input(
       z.object({
-        landingUrl: z
-          .string()
-          .default(HOME)
-          .refine((url) => isRelativeUrl(url), {
-            message: 'Invalid landing URL',
-          }),
+        landingUrl: callbackUrlSchema,
       }),
     )
     .mutation(async ({ ctx, input: { landingUrl } }) => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -19,7 +19,6 @@ export const getRedirectUrl = (query: ParsedUrlQuery) => {
 // Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
 // Adapted from https://github.com/sindresorhus/is-absolute-url/blob/main/index.js
 export const isRelativeUrl = (url: string) => {
-
   const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*?:/
   const PROTOCOL_RELATIVE_URL_REGEX = /^\/\//
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -2,7 +2,7 @@ import { type ParsedUrlQuery } from 'querystring'
 import { CALLBACK_URL_KEY } from '~/constants/params'
 
 export const appendWithRedirect = (url: string, redirectUrl?: string) => {
-  if (!redirectUrl) {
+  if (!redirectUrl || !isRelativeUrl(redirectUrl)) {
     return url
   }
   return `${url}?${CALLBACK_URL_KEY}=${redirectUrl}`
@@ -13,4 +13,22 @@ export const getRedirectUrl = (query: ParsedUrlQuery) => {
     return undefined
   }
   return decodeURIComponent(String(query[CALLBACK_URL_KEY]))
+}
+
+// Scheme: https://tools.ietf.org/html/rfc3986#section-3.1
+// Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
+// Adapted from https://github.com/sindresorhus/is-absolute-url/blob/main/index.js
+export const isRelativeUrl = (url: string) => {
+
+  const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*?:/
+  const PROTOCOL_RELATIVE_URL_REGEX = /^\/\//
+
+  // Windows paths like `c:\`
+  const WINDOWS_PATH_REGEX = /^[a-zA-Z]:\\/
+
+  if (WINDOWS_PATH_REGEX.test(url)) {
+    return false
+  }
+
+  return !ABSOLUTE_URL_REGEX.test(url) && !PROTOCOL_RELATIVE_URL_REGEX.test(url)
 }


### PR DESCRIPTION
Fixing a possible open redirect via URL parameter in the `callbackUrl` URL parameter that is appended to the URL when a redirect occurs due to the application session expiring (and receiving a 401 from the server)