### PR TITLE
fix: additional fix for possible xss injection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,4 @@ SGID_PRIVATE_KEY=
 # Other settings
 # ================
 # NEXT_PUBLIC_APP_NAME= # Uncomment to set application name
+# NEXT_PUBLIC_APP_URL= # Uncomment to set application URL

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -17,6 +17,7 @@ const coerceBoolean = z
 const client = z.object({
   NEXT_PUBLIC_ENABLE_STORAGE: coerceBoolean.default('false'),
   NEXT_PUBLIC_ENABLE_SGID: coerceBoolean.default('false'),
+  NEXT_PUBLIC_APP_URL: z.string().url().optional(),
   NEXT_PUBLIC_APP_NAME: z.string().default('Starter Kit'),
   NEXT_PUBLIC_APP_VERSION: z.string().default('0.0.0'),
 })
@@ -179,7 +180,7 @@ if (!!process.env.SKIP_ENV_VALIDATION == false) {
   if (parsed.success === false) {
     console.error(
       '❌ Invalid environment variables:',
-      parsed.error.flatten().fieldErrors
+      parsed.error.flatten().fieldErrors,
     )
     throw new Error('Invalid environment variables')
   }
@@ -193,7 +194,7 @@ if (!!process.env.SKIP_ENV_VALIDATION == false) {
         throw new Error(
           process.env.NODE_ENV === 'production'
             ? '❌ Attempted to access a server-side environment variable on the client'
-            : `❌ Attempted to access server-side environment variable '${prop}' on the client`
+            : `❌ Attempted to access server-side environment variable '${prop}' on the client`,
         )
       return target[/** @type {keyof typeof target} */ (prop)]
     },
@@ -205,7 +206,7 @@ if (!!process.env.SKIP_ENV_VALIDATION == false) {
   if (parsed.success === false) {
     console.error(
       '❌ Invalid environment variables:',
-      parsed.error.flatten().fieldErrors
+      parsed.error.flatten().fieldErrors,
     )
     throw new Error('Invalid environment variables')
   }

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -157,6 +157,7 @@ const processEnv = {
     process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
   NEXT_PUBLIC_ENABLE_STORAGE: process.env.NEXT_PUBLIC_ENABLE_STORAGE,
   NEXT_PUBLIC_ENABLE_SGID: process.env.NEXT_PUBLIC_ENABLE_SGID,
+  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
 }
 
 // Don't touch the part below

--- a/src/utils/getBaseUrl.ts
+++ b/src/utils/getBaseUrl.ts
@@ -1,10 +1,15 @@
+import { env } from '~/env.mjs'
+
 /**
  * Retrieves the base URL for the current environment.
  * @note Server-only utility function.
  */
 export const getBaseUrl = () => {
   if (typeof window !== 'undefined') {
-    return ''
+    return window.location.origin
+  }
+  if (env.NEXT_PUBLIC_APP_URL) {
+    return env.NEXT_PUBLIC_APP_URL
   }
   // reference for vercel.com
   if (process.env.VERCEL_URL) {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,6 @@
 import { type ParsedUrlQuery } from 'querystring'
 import { CALLBACK_URL_KEY } from '~/constants/params'
+import { getBaseUrl } from './getBaseUrl'
 
 export const appendWithRedirect = (url: string, redirectUrl?: string) => {
   if (!redirectUrl || !isRelativeUrl(redirectUrl)) {
@@ -15,19 +16,12 @@ export const getRedirectUrl = (query: ParsedUrlQuery) => {
   return decodeURIComponent(String(query[CALLBACK_URL_KEY]))
 }
 
-// Scheme: https://tools.ietf.org/html/rfc3986#section-3.1
-// Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
-// Adapted from https://github.com/sindresorhus/is-absolute-url/blob/main/index.js
 export const isRelativeUrl = (url: string) => {
-  const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*?:/
-  const PROTOCOL_RELATIVE_URL_REGEX = /^\/\//
-
-  // Windows paths like `c:\`
-  const WINDOWS_PATH_REGEX = /^[a-zA-Z]:\\/
-
-  if (WINDOWS_PATH_REGEX.test(url)) {
+  const baseUrl = getBaseUrl()
+  try {
+    const normalizedUrl = new URL(url, baseUrl)
+    return new URL(baseUrl).origin === normalizedUrl.origin
+  } catch (e) {
     return false
   }
-
-  return !ABSOLUTE_URL_REGEX.test(url) && !PROTOCOL_RELATIVE_URL_REGEX.test(url)
 }


### PR DESCRIPTION
The previous fix in #274 was not enough and there are some possible strings that could still bypass the `isRelativeUrl` check. This PR adds in a new environment variable `NEXT_PUBLIC_APP_URL` (only required-ish on non-vercel deployments)  to correctly ascertain that the URL to check is a relative URL, by comparing origins and ensuring both origins match.
