### PR TITLE
fix: add content type header middleware

### DIFF
--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -96,8 +96,8 @@ const loggerWithVersionMiddleware = loggerMiddleware.unstable_pipe(
   },
 )
 
-const baseMiddleware = t.middleware(async ({ ctx, next }) => {
-  // Only allow application/json content type
+const contentTypeHeaderMiddleware = t.middleware(async ({ ctx, next }) => {
+  console.log('TEMP', ctx.req.headers)
   if (
     ctx.req.body &&
     !ctx.req.headers['content-type']?.startsWith('application/json')
@@ -107,7 +107,10 @@ const baseMiddleware = t.middleware(async ({ ctx, next }) => {
       message: 'Invalid Content-Type',
     })
   }
+  return next()
+})
 
+const baseMiddleware = t.middleware(async ({ ctx, next }) => {
   if (ctx.session === undefined) {
     throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR' })
   }
@@ -168,6 +171,7 @@ export const router = t.router
  **/
 export const publicProcedure = t.procedure
   .use(loggerWithVersionMiddleware)
+  .use(contentTypeHeaderMiddleware)
   .use(baseMiddleware)
 
 /**
@@ -175,10 +179,12 @@ export const publicProcedure = t.procedure
  **/
 export const protectedProcedure = t.procedure
   .use(loggerWithVersionMiddleware)
+  .use(contentTypeHeaderMiddleware)
   .use(authMiddleware)
 
 export const agnosticProcedure = t.procedure
   .use(loggerWithVersionMiddleware)
+  .use(contentTypeHeaderMiddleware)
   .use(nonStrictAuthMiddleware)
 
 /**

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -97,6 +97,17 @@ const loggerWithVersionMiddleware = loggerMiddleware.unstable_pipe(
 )
 
 const baseMiddleware = t.middleware(async ({ ctx, next }) => {
+  // Only allow application/json content type
+  if (
+    ctx.req.body &&
+    !ctx.req.headers['content-type']?.startsWith('application/json')
+  ) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Invalid Content-Type',
+    })
+  }
+
   if (ctx.session === undefined) {
     throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR' })
   }

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -97,7 +97,6 @@ const loggerWithVersionMiddleware = loggerMiddleware.unstable_pipe(
 )
 
 const contentTypeHeaderMiddleware = t.middleware(async ({ ctx, next }) => {
-  console.log('TEMP', ctx.req.headers)
   if (
     ctx.req.body &&
     !ctx.req.headers['content-type']?.startsWith('application/json')

--- a/tests/integration/helpers/iron-session.ts
+++ b/tests/integration/helpers/iron-session.ts
@@ -52,11 +52,20 @@ class MockIronStore {
 export const createMockRequest = async (
   session: Session,
   reqOptions: RequestOptions = { method: 'GET' },
-  resOptions?: ResponseOptions
+  resOptions?: ResponseOptions,
 ): Promise<Context> => {
   const innerContext = await createContextInner({ session })
 
-  const { req, res } = createMocks(reqOptions, resOptions)
+  const { req, res } = createMocks(
+    {
+      ...reqOptions,
+      headers: {
+        'content-type': 'application/json', // will always be application/json
+        ...reqOptions.headers,
+      },
+    },
+    resOptions,
+  )
 
   return {
     ...innerContext,


### PR DESCRIPTION
This PR adds an additional middleware to ensure that the Content-Type of requests with request body are enforced as application/json.