### PR TITLE
feat: disable retries on mutations

### DIFF
--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -202,9 +202,7 @@ export const trpc = createTRPCNext<
             },
           },
           mutations: {
-            retry: (_, error) => {
-              return isErrorRetryableOnClient(error)
-            },
+            retry: false,
           },
         },
       },


### PR DESCRIPTION
When a mutation returns an error that is deemed retryable, it retries. This "feature" may result in multiple POST requests on error codes deemed retryable, which may not be the expected behaviour. For avoidance of any possible idempotency issue, retries are turned off on mutations.