### PR TITLE
refactor: url and email validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6135,7 +6135,7 @@
     },
     "node_modules/@opengovsg/starter-kitty-validators": {
       "version": "1.2.5",
-      "resolved": "https://npm.pkg.github.com/download/@opengovsg/starter-kitty-validators/1.2.5/600f1bf10d5aa7f9711c1c0f3fc2e787b334bb04",
+      "resolved": "https://registry.npmjs.org/@opengovsg/starter-kitty-validators/-/starter-kitty-validators-1.2.5.tgz",
       "integrity": "sha512-kIEDNcQJEZoKxFioRrbzemMJ0x1hanKef3HhVN8liokAZKPiDsxAGzqmW9gCFRX6SxNq83YRanyy9WF1FCOIPA==",
       "dependencies": {
         "email-addresses": "^5.0.0",
@@ -32773,7 +32773,7 @@
     },
     "@opengovsg/starter-kitty-validators": {
       "version": "1.2.5",
-      "resolved": "https://npm.pkg.github.com/download/@opengovsg/starter-kitty-validators/1.2.5/600f1bf10d5aa7f9711c1c0f3fc2e787b334bb04",
+      "resolved": "https://registry.npmjs.org/@opengovsg/starter-kitty-validators/-/starter-kitty-validators-1.2.5.tgz",
       "integrity": "sha512-kIEDNcQJEZoKxFioRrbzemMJ0x1hanKef3HhVN8liokAZKPiDsxAGzqmW9gCFRX6SxNq83YRanyy9WF1FCOIPA==",
       "requires": {
         "email-addresses": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@hookform/resolvers": "^3.3.4",
         "@opengovsg/design-system-react": "^1.15.0",
         "@opengovsg/sgid-client": "^2.2.0",
-        "@opengovsg/starter-kitty-validators": "^1.0.1",
+        "@opengovsg/starter-kitty-validators": "^1.2.5",
         "@paralleldrive/cuid2": "^2.2.2",
         "@prisma/client": "^5.7.1",
         "@sendgrid/mail": "^8.1.3",
@@ -6134,10 +6134,11 @@
       }
     },
     "node_modules/@opengovsg/starter-kitty-validators": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@opengovsg/starter-kitty-validators/-/starter-kitty-validators-1.0.1.tgz",
-      "integrity": "sha512-jPJyR9yFvUnkTJc4xgNLyo6bzzbPWKw6V0aYSZOl/SHR9Ll613VhAOIJ1YUEkIwq4TB9o/ciDnWCuDuJMmFtFQ==",
+      "version": "1.2.5",
+      "resolved": "https://npm.pkg.github.com/download/@opengovsg/starter-kitty-validators/1.2.5/600f1bf10d5aa7f9711c1c0f3fc2e787b334bb04",
+      "integrity": "sha512-kIEDNcQJEZoKxFioRrbzemMJ0x1hanKef3HhVN8liokAZKPiDsxAGzqmW9gCFRX6SxNq83YRanyy9WF1FCOIPA==",
       "dependencies": {
+        "email-addresses": "^5.0.0",
         "zod": "^3.23.8",
         "zod-validation-error": "^3.3.0"
       }
@@ -14925,6 +14926,12 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
+    },
+    "node_modules/email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "license": "MIT"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -32765,10 +32772,11 @@
       }
     },
     "@opengovsg/starter-kitty-validators": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@opengovsg/starter-kitty-validators/-/starter-kitty-validators-1.0.1.tgz",
-      "integrity": "sha512-jPJyR9yFvUnkTJc4xgNLyo6bzzbPWKw6V0aYSZOl/SHR9Ll613VhAOIJ1YUEkIwq4TB9o/ciDnWCuDuJMmFtFQ==",
+      "version": "1.2.5",
+      "resolved": "https://npm.pkg.github.com/download/@opengovsg/starter-kitty-validators/1.2.5/600f1bf10d5aa7f9711c1c0f3fc2e787b334bb04",
+      "integrity": "sha512-kIEDNcQJEZoKxFioRrbzemMJ0x1hanKef3HhVN8liokAZKPiDsxAGzqmW9gCFRX6SxNq83YRanyy9WF1FCOIPA==",
       "requires": {
+        "email-addresses": "^5.0.0",
         "zod": "^3.23.8",
         "zod-validation-error": "^3.3.0"
       }
@@ -39162,6 +39170,11 @@
           "dev": true
         }
       }
+    },
+    "email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw=="
     },
     "emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@hookform/resolvers": "^3.3.4",
     "@opengovsg/design-system-react": "^1.15.0",
     "@opengovsg/sgid-client": "^2.2.0",
-    "@opengovsg/starter-kitty-validators": "^1.0.1",
+    "@opengovsg/starter-kitty-validators": "^1.2.5",
     "@paralleldrive/cuid2": "^2.2.2",
     "@prisma/client": "^5.7.1",
     "@sendgrid/mail": "^8.1.3",

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,4 +1,9 @@
+import { createEmailSchema } from '@opengovsg/starter-kitty-validators/email'
 import isEmail from 'validator/lib/isEmail'
+
+const emailSchema = createEmailSchema({
+  domains: [{ domain: 'gov.sg', includeSubdomains: true }],
+})
 
 export const getEmailDomain = (email?: string) => {
   if (!email) {
@@ -15,6 +20,8 @@ export const getEmailDomain = (email?: string) => {
  */
 export const isGovEmail = (value: unknown) => {
   return (
-    typeof value === 'string' && isEmail(value) && value.endsWith('.gov.sg')
+    typeof value === 'string' &&
+    isEmail(value) &&
+    emailSchema.safeParse(value).success
   )
 }


### PR DESCRIPTION
This PR replaces `UrlValidator` with the newer `createUrlSchema` API from starter-kitty, which is more concise and extendable for use with Zod schemas. It also replaces the `.endsWith` check for `.gov.sg` emails with [`createEmailSchema`](https://kit.open.gov.sg/examples/validators.html#email-validation), which is safe to extend for more custom use cases, e.g. multiple domains, subdomain vs. full match only, etc.