### PR TITLE
feat: try ci coverage generation without dotenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
           languages: js
           service: ${{ secrets.DD_SERVICE_NAME }}
           api_key: ${{ secrets.DD_API_KEY }}
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v2
+        with:
+          mode: test
       - name: Test
         run: npm run test-ci:coverage
         env:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:vitest": "dotenv -e .env.test vitest run",
     "test-dev:vitest": "dotenv -e .env.test vitest",
     "test:e2e": "dotenv -e .env.test playwright test",
-    "test-ci:coverage": "dotenv -e .env.test vitest run -- --coverage",
+    "test-ci:coverage": "vitest run --coverage",
     "test-ci:e2e": "start-server-and-test start http://127.0.0.1:3000 test:e2e",
     "test-dev:e2e": "start-server-and-test dev http://127.0.0.1:3000 test:e2e",
     "load-test:build": "webpack --config tests/load/webpack.config.js",


### PR DESCRIPTION
seems to prevent datadog from piping coverage data