### PR TITLE
feat: remove redundant db query in me.get

### DIFF
--- a/src/server/modules/me/me.router.ts
+++ b/src/server/modules/me/me.router.ts
@@ -3,13 +3,11 @@
  * This is an example router, you can delete this file and then update `../pages/api/trpc/[trpc].tsx`
  */
 import { protectedProcedure, router } from '~/server/trpc'
-import { defaultMeSelect } from './me.select'
 
 export const meRouter = router({
   get: protectedProcedure.query(async ({ ctx }) => {
-    return await ctx.prisma.user.findUniqueOrThrow({
-      where: { id: ctx.user.id },
-      select: defaultMeSelect,
-    })
+    // Remember to write a new query if you want to return something different than what
+    // the authMiddleware in protectedProcedure returns.
+    return ctx.user
   }),
 })


### PR DESCRIPTION
### TL;DR
Simplified user data retrieval by using existing context data instead of making a database query.

### What changed?
Removed the database query in the `me.router.ts` file and directly returned the user data from the context (`ctx.user`) that's already available through the `protectedProcedure`.

### How to test?
1. Make a request to the `/me` endpoint while authenticated
2. Verify that the user data is still returned correctly
3. Confirm that the response time has improved due to the eliminated database query

### Why make this change?
The `protectedProcedure` already includes the necessary user data in its context, making the additional database query redundant. This change improves performance by eliminating an unnecessary database call while maintaining the same functionality.