### PR TITLE
fix: urlencode redirect url

### DIFF
--- a/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
+++ b/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
@@ -15,7 +15,9 @@ interface EnforceLoginStatePageWrapperProps {
   redirectTo?: string
 }
 
-const Redirect = ({ redirectTo = SIGN_IN }: EnforceLoginStatePageWrapperProps) => {
+const Redirect = ({
+  redirectTo = SIGN_IN,
+}: EnforceLoginStatePageWrapperProps) => {
   const router = useRouter()
   const redirectUrl = useMemo(() => {
     if (typeof window === 'undefined') return '/'
@@ -24,9 +26,7 @@ const Redirect = ({ redirectTo = SIGN_IN }: EnforceLoginStatePageWrapperProps) =
   }, [])
 
   void router.replace(
-    callbackUrlSchema.parse(
-      appendWithRedirect(redirectTo, redirectUrl),
-    ),
+    callbackUrlSchema.parse(appendWithRedirect(redirectTo, redirectUrl)),
   )
 
   return <FullscreenSpinner />

--- a/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
+++ b/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
@@ -15,17 +15,17 @@ interface EnforceLoginStatePageWrapperProps {
   redirectTo?: string
 }
 
-const Redirect = ({ redirectTo }: EnforceLoginStatePageWrapperProps) => {
+const Redirect = ({ redirectTo = SIGN_IN }: EnforceLoginStatePageWrapperProps) => {
   const router = useRouter()
   const redirectUrl = useMemo(() => {
     if (typeof window === 'undefined') return encodeURIComponent('/')
     const { pathname, search, hash } = window.location
-    return encodeURIComponent(`${pathname}${search}${hash}`)
+    return `${pathname}${search}${hash}`
   }, [])
 
   void router.replace(
     callbackUrlSchema.parse(
-      appendWithRedirect(redirectTo ?? SIGN_IN, redirectUrl),
+      appendWithRedirect(redirectTo, redirectUrl),
     ),
   )
 

--- a/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
+++ b/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
@@ -18,7 +18,7 @@ interface EnforceLoginStatePageWrapperProps {
 const Redirect = ({ redirectTo = SIGN_IN }: EnforceLoginStatePageWrapperProps) => {
   const router = useRouter()
   const redirectUrl = useMemo(() => {
-    if (typeof window === 'undefined') return encodeURIComponent('/')
+    if (typeof window === 'undefined') return '/'
     const { pathname, search, hash } = window.location
     return `${pathname}${search}${hash}`
   }, [])

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -7,7 +7,7 @@ export const appendWithRedirect = (url: string, redirectUrl?: string) => {
   if (!redirectUrl || !isRelativeUrl(redirectUrl)) {
     return url
   }
-  return `${url}?${CALLBACK_URL_KEY}=${redirectUrl}`
+  return `${url}?${CALLBACK_URL_KEY}=${encodeURIComponent(redirectUrl)}`
 }
 
 export const getRedirectUrl = (query: ParsedUrlQuery) => {


### PR DESCRIPTION
### Context
Utility function `appendWithRedirect` has the following code
```typescript
export const appendWithRedirect = (url: string, redirectUrl?: string) => {
  if (!redirectUrl || !isRelativeUrl(redirectUrl)) {
    return url
  }
  return `${url}?${CALLBACK_URL_KEY}=${redirectUrl}`
}
```

However, `redirectUrl` should be encoded with `encodeURIComponent`.

In the `Redirect` component, the encoding there is thereby removed. 


### Tests
Manually tested simple flow
`localhost:3002/home` -> `http://localhost:3002/sign-in?callbackUrl=%2Fhome` -> `http://localhost:3002/home`
