### PR TITLE
feat: make node_env checks safe by default

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,7 @@ const ContentSecurityPolicy = `
   };
   frame-src 'self';
   object-src 'none';
-  script-src 'self' ${['test', 'development'].includes(env.NODE_ENV) ? "'unsafe-eval'" : ""};
+  script-src 'self' ${['test', 'development'].includes(env.NODE_ENV) ? "'unsafe-eval'" : ''};
   style-src 'self' https: 'unsafe-inline';
   connect-src 'self' https://browser-intake-datadoghq.com https://*.browser-intake-datadoghq.com https://vitals.vercel-insights.com/v1/vitals ${
     // For POSTing presigned URLs to R2 storage.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,7 @@ const ContentSecurityPolicy = `
   };
   frame-src 'self';
   object-src 'none';
-  script-src 'self' ${env.NODE_ENV === 'production' ? '' : "'unsafe-eval'"};
+  script-src 'self' ${['test', 'development'].includes(env.NODE_ENV) ? "'unsafe-eval'" : ""};
   style-src 'self' https: 'unsafe-inline';
   connect-src 'self' https://browser-intake-datadoghq.com https://*.browser-intake-datadoghq.com https://vitals.vercel-insights.com/v1/vitals ${
     // For POSTing presigned URLs to R2 storage.
@@ -25,7 +25,7 @@ const ContentSecurityPolicy = `
       : ''
   };
   worker-src 'self' blob:;
-  ${env.NODE_ENV === 'production' ? 'upgrade-insecure-requests' : ''}
+  ${['test', 'development'].includes(env.NODE_ENV) ? '' : 'upgrade-insecure-requests'}
 `
 
 /**

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -193,7 +193,7 @@ if (!!process.env.SKIP_ENV_VALIDATION == false) {
       // Otherwise it would just be returning `undefined` and be annoying to debug
       if (!isServer && !prop.startsWith('NEXT_PUBLIC_'))
         throw new Error(
-          process.env.NODE_ENV === 'production'
+          !['test', 'development'].includes(env.NODE_ENV)
             ? '❌ Attempted to access a server-side environment variable on the client'
             : `❌ Attempted to access server-side environment variable '${prop}' on the client`,
         )

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -193,9 +193,9 @@ if (!!process.env.SKIP_ENV_VALIDATION == false) {
       // Otherwise it would just be returning `undefined` and be annoying to debug
       if (!isServer && !prop.startsWith('NEXT_PUBLIC_'))
         throw new Error(
-          !['test', 'development'].includes(env.NODE_ENV)
-            ? '❌ Attempted to access a server-side environment variable on the client'
-            : `❌ Attempted to access server-side environment variable '${prop}' on the client`,
+          ['test', 'development'].includes(env.NODE_ENV)
+            ? `❌ Attempted to access server-side environment variable '${prop}' on the client`
+            : '❌ Attempted to access a server-side environment variable on the client',
         )
       return target[/** @type {keyof typeof target} */ (prop)]
     },

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,7 +34,7 @@ const MyApp = ((props: AppPropsWithAuthAndLayout) => {
                 <Stack spacing={0} minH="$100vh">
                   <VersionWrapper />
                   <ChildWithLayout {...props} />
-                  {process.env.NODE_ENV !== 'production' && (
+                  {['test', 'development'].includes(env.NODE_ENV) && (
                     <ReactQueryDevtools initialIsOpen={false} />
                   )}
                 </Stack>

--- a/src/server/modules/auth/session.ts
+++ b/src/server/modules/auth/session.ts
@@ -9,6 +9,6 @@ export const sessionOptions: SessionOptions = {
   cookieName: 'auth.session-token',
   ttl: 60 * 60 * 24 * 7, // 7 days
   cookieOptions: {
-    secure: env.NODE_ENV === 'production',
+    secure: env.NODE_ENV !== 'development' && env.NODE_ENV !== 'test',
   },
 }

--- a/src/server/prisma.ts
+++ b/src/server/prisma.ts
@@ -16,6 +16,6 @@ export const prisma: PrismaClient =
     log: env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],
   })
 
-if (env.NODE_ENV !== 'production') {
+if (['test', 'development'].includes(env.NODE_ENV)) {
   prismaGlobal.prisma = prisma
 }


### PR DESCRIPTION
### Context

There are several checks scattered across starter-kit that follow the pattern `env.NODE_ENV === production ? 'safe': 'unsafe'`.
This is unsafe by default because if `NODE_ENV` is not set in the deployment, it will be `undefined`, falling back to an unsafe value.

This has previously led to [wrong CSP headers being set on production instance of ActiveSG](https://github.com/opengovsg/activesg/pull/2189/).

### Approach
The unsafe pattern has been replaced with either
- `['test', 'development'].includes(env.NODE_ENV)`
- `env.NODE_ENV !== 'test' && env.NODE_ENV !== 'development'`

where appropriate.

### Testing
No testing was done because the checks are logically equivalent.