### PR TITLE
fix: fe crash due to referencing server env var NODE_ENV

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -193,7 +193,7 @@ if (!!process.env.SKIP_ENV_VALIDATION == false) {
       // Otherwise it would just be returning `undefined` and be annoying to debug
       if (!isServer && !prop.startsWith('NEXT_PUBLIC_'))
         throw new Error(
-          ['test', 'development'].includes(env.NODE_ENV)
+          ['test', 'development'].includes(process.env.NODE_ENV)
             ? `❌ Attempted to access server-side environment variable '${prop}' on the client`
             : '❌ Attempted to access a server-side environment variable on the client',
         )

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,9 +34,7 @@ const MyApp = ((props: AppPropsWithAuthAndLayout) => {
                 <Stack spacing={0} minH="$100vh">
                   <VersionWrapper />
                   <ChildWithLayout {...props} />
-                  {['test', 'development'].includes(env.NODE_ENV) && (
-                    <ReactQueryDevtools initialIsOpen={false} />
-                  )}
+                  <ReactQueryDevtools initialIsOpen={false} />
                 </Stack>
               </Suspense>
             </ErrorBoundary>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,7 +34,9 @@ const MyApp = ((props: AppPropsWithAuthAndLayout) => {
                 <Stack spacing={0} minH="$100vh">
                   <VersionWrapper />
                   <ChildWithLayout {...props} />
-                  <ReactQueryDevtools initialIsOpen={false} />
+                  {['test', 'development'].includes(process.env.NODE_ENV) && (
+                    <ReactQueryDevtools initialIsOpen={false} />
+                  )}
                 </Stack>
               </Suspense>
             </ErrorBoundary>


### PR DESCRIPTION
### Context

FE was crashing due to referencing server env var `NODE_ENV` in `src/pages/_app.tsx`

This issue comes from PR #383 where we replaced `NODE_ENV` references.

### Root cause

1. Failure to differentiate between `env.NODE_ENV` and `process.env.NODE_ENV`:
- `env.NODE_ENV` is evaluated at runtime
- `process.env.NODE_ENV` is baked during build time.

2. Human factors:
- Lack of manual testing in previous PR (#383)
- Merging the PR before the CI pipeline completed its checks

### Approach & Testing
- Corrected all `NODE_ENV` references to the appropriate types (runtime vs build time)
- Tested locally with `npm run dev` and `npm run build && npm run start`, works perfectly.

