### PR TITLE
chore: improve sgid state validation

### DIFF
--- a/src/features/sign-in/components/SgidErrorFallback/SgidErrorFallback.tsx
+++ b/src/features/sign-in/components/SgidErrorFallback/SgidErrorFallback.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod'
 
 import { safeSchemaJsonParse } from '~/utils/zod'
 import { HOME } from '~/lib/routes'
+import { callbackUrlSchema } from '~/schemas/url'
 import { SgidErrorModal } from './SgidErrorModal'
 
 export const SgidErrorFallback: ComponentType<FallbackProps> = ({ error }) => {
@@ -12,12 +13,12 @@ export const SgidErrorFallback: ComponentType<FallbackProps> = ({ error }) => {
   const redirectUrl = useMemo(() => {
     const parsed = safeSchemaJsonParse(
       z.object({
-        landingUrl: z.string(),
+        landingUrl: callbackUrlSchema,
       }),
       String(router.query.state),
     )
     if (parsed.success) {
-      return parsed.data.landingUrl
+      return parsed.data.landingUrl.href
     }
     return HOME
   }, [router.query.state])

--- a/src/features/sign-in/components/SgidLogin/SgidLoginButton.tsx
+++ b/src/features/sign-in/components/SgidLogin/SgidLoginButton.tsx
@@ -5,12 +5,13 @@ import { Button } from '@opengovsg/design-system-react'
 import { trpc } from '~/utils/trpc'
 import { getRedirectUrl } from '~/utils/url'
 import { SingpassFullLogo } from '~/components/Svg/SingpassFullLogo'
+import { callbackUrlSchema } from '~/schemas/url'
 
 export const SgidLoginButton = (): JSX.Element | null => {
   const router = useRouter()
   const sgidLoginMutation = trpc.auth.sgid.login.useMutation({
     onSuccess: async ({ redirectUrl }) => {
-      await router.push(redirectUrl)
+      await router.push(callbackUrlSchema.parse(redirectUrl))
     },
   })
 

--- a/src/features/sign-in/components/SgidLogin/SgidLoginButton.tsx
+++ b/src/features/sign-in/components/SgidLogin/SgidLoginButton.tsx
@@ -15,7 +15,7 @@ export const SgidLoginButton = (): JSX.Element | null => {
     },
   })
 
-  const landingUrl = getRedirectUrl(router.query)
+  const landingUrl = callbackUrlSchema.parse(getRedirectUrl(router.query))
 
   const handleSgidLogin = () => {
     return sgidLoginMutation.mutate({

--- a/src/features/sign-in/components/SgidLogin/SgidLoginButton.tsx
+++ b/src/features/sign-in/components/SgidLogin/SgidLoginButton.tsx
@@ -11,7 +11,7 @@ export const SgidLoginButton = (): JSX.Element | null => {
   const router = useRouter()
   const sgidLoginMutation = trpc.auth.sgid.login.useMutation({
     onSuccess: async ({ redirectUrl }) => {
-      await router.push(callbackUrlSchema.parse(redirectUrl))
+      await router.push(redirectUrl)
     },
   })
 

--- a/src/features/sign-in/components/SgidLogin/SgidLoginButton.tsx
+++ b/src/features/sign-in/components/SgidLogin/SgidLoginButton.tsx
@@ -15,7 +15,7 @@ export const SgidLoginButton = (): JSX.Element | null => {
     },
   })
 
-  const landingUrl = callbackUrlSchema.parse(getRedirectUrl(router.query))
+  const landingUrl = callbackUrlSchema.parse(getRedirectUrl(router.query)).href
 
   const handleSgidLogin = () => {
     return sgidLoginMutation.mutate({

--- a/src/schemas/url.ts
+++ b/src/schemas/url.ts
@@ -6,17 +6,27 @@ import { HOME } from '~/lib/routes'
 
 const baseUrl = new URL(getBaseUrl())
 
+const urlSchema = createUrlSchema({
+  baseOrigin: baseUrl.origin,
+  whitelist: {
+    protocols: ['http', 'https'],
+    hosts: [baseUrl.host],
+  },
+})
+
 export const callbackUrlSchema = z
   .string()
   .optional()
   .default(HOME)
-  .pipe(
-    createUrlSchema({
-      baseOrigin: baseUrl.origin,
-      whitelist: {
-        protocols: ['http', 'https'],
-        hosts: [baseUrl.host],
-      },
-    }),
-  )
+  .transform((val, ctx) => {
+    try {
+      return urlSchema.parse(val)
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'URL validation error',
+      })
+      return z.NEVER
+    }
+  })
   .catch(new URL(HOME, baseUrl.origin))

--- a/src/server/modules/auth/sgid/sgid.router.ts
+++ b/src/server/modules/auth/sgid/sgid.router.ts
@@ -155,7 +155,7 @@ export const sgidRouter = router({
         selectProfileStep: true,
         redirectUrl: appendWithRedirect(
           `${SIGN_IN}${SIGN_IN_SELECT_PROFILE_SUBROUTE}`,
-          parsedState.data.landingUrl,
+          parsedState.data.landingUrl.href,
         ),
       }
     }),

--- a/src/server/modules/auth/sgid/sgid.router.ts
+++ b/src/server/modules/auth/sgid/sgid.router.ts
@@ -23,16 +23,12 @@ import {
 } from './sgid.utils'
 
 const sgidCallbackStateSchema = z.object({
-  landingUrl: z.string(),
+  landingUrl: callbackUrlSchema,
 })
 
 export const sgidRouter = router({
   login: publicProcedure
-    .input(
-      z.object({
-        landingUrl: callbackUrlSchema,
-      }),
-    )
+    .input(sgidCallbackStateSchema)
     .mutation(async ({ ctx, input: { landingUrl } }) => {
       if (!sgid) {
         throw new TRPCError({


### PR DESCRIPTION
## Context

The SGID OIDC login flow, while currently safe, is prone to open redirect vulnerabilities related to the `landingUrl` parameter. This URL is passed into the `state` parameter and is derived from query params. There is insufficient validation in between the steps of the login flow, thus is quite prone to open redirect vulnerabilities.

This has occurred in [kampung-spirit recently](https://github.com/opengovsg/kampung-spirit/pull/388/) and could be partially exploitable in `armoury`.

## Approach

To mitigate this, we propose the following changes:

1. **Client-side validation**: Implement validation of the `landingUrl` on the client side and fallback to a safe URL.

2. **Server-side validation**: Add server-side validation in both legs of OIDC and always fallback to a safe URL.

3. **Error fallback component**: Add validation for the `landingUrl` in the error fallback component.

## Risks
- Disruption to login flow if validation logic is too strict.
- callbackUrlSchema adjusted to fail gracefully and default to HOME. 
  - This seems like the intended behavior, but may affect codepaths that relied on callbackUrlSchema throwing errors.

## Testing

### Happy SGID flow
- Tested login flow on https://starter-5jcverdf5-ogp-tooling.vercel.app/
- Note: oidc callback url is hardcoded to `https://ogp-starter-kit.vercel.app/` via `env.SGID_REDIRECT_URI`, so you need to use the callback code manually like so: 
```
https://starter-5jcverdf5-ogp-tooling.vercel.app/sign-in/sgid/callback?code=YOUR_CODE&state=%7B%22landingUrl%22%3A%22https%3A%2F%2Fstarter-5jcverdf5-ogp-tooling.vercel.app%2Fhome%22%7D
```

### Happy SGID flow with custom path `/404'
- Tested login flow on https://starter-5jcverdf5-ogp-tooling.vercel.app/sign-in?callbackUrl=/404
- Redirects to `https://starter-5jcverdf5-ogp-tooling.vercel.app/404` after login

### Happy email flow
- Tested email login flow, no issues

### Testing client side validation
With bad callbackUrl `https://starter-5jcverdf5-ogp-tooling.vercel.app/sign-in?callbackUrl=https://evil.com`, the request to sgid login `state.landingUrl` fallbacks to `https://starter-5jcverdf5-ogp-tooling.vercel.app/home`

### Testing server side validation on leg 1
With bad state.landingUrl submitted to `/api/trpc/auth.sgid.login`, response `redirectUrl` has query state `{"landingUrl":"https://starter-5jcverdf5-ogp-tooling.vercel.app/home"}`

### Testing server side validation on leg 2
With bad state.landingUrl submitted to `/api/trpc/auth.sgid.callback`, response json
```
[{"result":{"data":{"json":{
  "selectProfileStep": true,
  "redirectUrl": "/sign-in/select-profile?callbackUrl=https%3A%2F%2Fstarter-5jcverdf5-ogp-tooling.vercel.app%2Fhome"
}}}}]
```

### Testing error fallback component
`redirectUrl` in `SgidErrorFallback` is sanitized.

