### PR TITLE
fix: normalise sgid email

### DIFF
--- a/src/server/modules/auth/sgid/sgid.router.ts
+++ b/src/server/modules/auth/sgid/sgid.router.ts
@@ -209,7 +209,8 @@ export const sgidRouter = router({
       ctx.session.destroy()
 
       const hasProfile = profiles.list.some(
-        (profile) => profile.work_email === email,
+        ({ work_email }) =>
+          work_email && normaliseEmail.parse(work_email) === email,
       )
       trpcAssert(hasProfile, {
         message: 'Error logging in via sgID: selected profile is invalid',

--- a/src/server/modules/auth/sgid/sgid.router.ts
+++ b/src/server/modules/auth/sgid/sgid.router.ts
@@ -9,7 +9,6 @@ import { z } from 'zod'
 import { trpcAssert } from '~/utils/trpcAssert'
 import { appendWithRedirect } from '~/utils/url'
 import { normaliseEmail, safeSchemaJsonParse } from '~/utils/zod'
-import { env } from '~/env.mjs'
 import { SGID } from '~/lib/errors/auth.sgid'
 import { SIGN_IN, SIGN_IN_SELECT_PROFILE_SUBROUTE } from '~/lib/routes'
 import { APP_SGID_SCOPE, sgid } from '~/lib/sgid'
@@ -80,7 +79,7 @@ export const sgidRouter = router({
       }),
     )
     .query(async ({ ctx, input: { state, code } }) => {
-      if (!env.NEXT_PUBLIC_ENABLE_SGID) {
+      if (!sgid) {
         ctx.logger.error('SGID is not enabled')
         throw new TRPCError({
           code: 'BAD_REQUEST',


### PR DESCRIPTION
### Context

After sgid login, the user is prompted to select a profile.
Whichever profile is selected, the email is sent to the server to be used as the primary identifier.
There is a validation step which checks that the email used is in one of the sgid profiles belonging to the user.
However, there is no case normalization performed on the sgid profile emails during this check.

Therefore, there could be a situation where the sgid profile emails are not lowercased, leading to an error when the user selects the profile.

### Approach
Normalize the `work_email` when checking if the user selected email is equal to it.

Additionally, the check for whether sgid login is enabled has been made consistent.