### PR TITLE
feat: add additional flag to allow skipping of server env validation

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -170,10 +170,11 @@ const processEnv = {
 let env = /** @type {MergedOutput} */ (process.env)
 
 if (!!process.env.SKIP_ENV_VALIDATION == false) {
+  const isBuild = !!process.env.BUILD_MODE // Allows building of docker image without server-side env validation
   const isServer = typeof window === 'undefined'
 
   const parsed = /** @type {MergedSafeParseReturn} */ (
-    isServer
+    isServer && !isBuild
       ? server.safeParse(processEnv) // on server we can validate all env vars
       : client.safeParse(processEnv) // on client we can only validate the ones that are exposed
   )


### PR DESCRIPTION
This pull request includes a change to the environment variable validation logic in the `src/env.mjs` file. The change introduces a new variable to allow building a Docker image without server-side environment validation.

Environment variable validation improvements:

* [`src/env.mjs`](diffhunk://#diff-4ed47d4643b7ec88e80c88221860b4c9eca9be1cb89d980ab40ed6087ae47caaR173-R177): Added a new constant `isBuild` to check for `BUILD_MODE` in the process environment, allowing the Docker image to be built without server-side environment validation.