### PR TITLE
feat: add output config to next.config.mjs for dockerfile replacement

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,7 +33,7 @@ const ContentSecurityPolicy = `
  */
 /** @type {import("next").NextConfig} */
 const config = {
-  /** The Dockerfile replaces this with `output: "standalone"` to allow a custom server */
+  /** A Dockerfile could replace this with `output: "standalone"` to allow a custom server */
   output: undefined,
   reactStrictMode: true,
   /**

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,6 +33,8 @@ const ContentSecurityPolicy = `
  */
 /** @type {import("next").NextConfig} */
 const config = {
+  /** The Dockerfile replaces this with `output: "standalone"` to allow a custom server */
+  output: undefined,
   reactStrictMode: true,
   /**
    * Dynamic configuration available for the browser and server.


### PR DESCRIPTION
This pull request includes a small change to the `next.config.mjs` file. The change adds a comment explaining that the Dockerfile replaces the `output` property with `"standalone"` to allow a custom server.