### PR TITLE
fix: pin github workflow actions to commit hash

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -29,12 +29,14 @@ jobs:
         if: env.CHROMATIC_PROJECT_TOKEN != ''
       - name: Load .env file
         if: env.CHROMATIC_PROJECT_TOKEN != ''
-        uses: xom9ikk/dotenv@v2
+        # xom9ikk/dotenv@v2, using commit hash to pin as tags may be updated in supply chain attack
+        uses: xom9ikk/dotenv@eff1dce037c4c0143cc4180a810511024c2560c0
         with:
           mode: test
       - name: Publish to Chromatic
         if: env.CHROMATIC_PROJECT_TOKEN != ''
-        uses: chromaui/action@latest
+        # chromaui/action@latest, using commit hash to pin to silence codeQL
+        uses: chromaui/action@012a0241a4df3f0f831c99f02e2085c9641a25ba
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,8 @@ jobs:
           DD_SERVICE_NAME: ${{ secrets.DD_SERVICE_NAME }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
         if: env.DD_SERVICE_NAME != '' && env.DD_API_KEY != ''
-        uses: datadog/test-visibility-github-action@v2
+        # datadog/test-visibility-github-action@v2.2.0, using commit hash to pin to silence codeQL
+        uses: datadog/test-visibility-github-action@fd12a97414bee507eff1270d8ac3286313e3797e
         with:
           languages: js
           service: ${{ secrets.DD_SERVICE_NAME }}
@@ -71,7 +72,8 @@ jobs:
       - name: Install Playwright (Chromium)
         run: npx playwright install chromium
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        # xom9ikk/dotenv@v2, using commit hash to pin as tags may be updated in supply chain attack
+        uses: xom9ikk/dotenv@eff1dce037c4c0143cc4180a810511024c2560c0
         with:
           mode: test
       - name: Next.js cache
@@ -98,7 +100,8 @@ jobs:
           DD_SERVICE_NAME: ${{ secrets.DD_SERVICE_NAME }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
         if: env.DD_SERVICE_NAME != '' && env.DD_API_KEY != ''
-        uses: datadog/test-visibility-github-action@v2
+        # datadog/test-visibility-github-action@v2.2.0, using commit hash to pin to silence codeQL
+        uses: datadog/test-visibility-github-action@fd12a97414bee507eff1270d8ac3286313e3797e
         with:
           languages: js
           service: ${{ secrets.DD_SERVICE_NAME }}


### PR DESCRIPTION
## Context

CodeQL generated alerts for not pinning actions to a specific commit hash.

This is a valid concern for certain actions, especially `xom9ikk/dotenv@v2`, as the maintainer can simply point `v2` at a malicious script instead and exfiltrate env vars.

For other actions, namely `datadog/test-visibility-github-action` and `chromaui/action`, we can trust that they have a proper release process, so actually there is no need to pin it.

For more information, see alerts ([1](https://github.com/opengovsg/starter-kit/security/code-scanning/1), [2](https://github.com/opengovsg/starter-kit/security/code-scanning/2), [3](https://github.com/opengovsg/starter-kit/security/code-scanning/3), [4](https://github.com/opengovsg/starter-kit/security/code-scanning/4), [5](https://github.com/opengovsg/starter-kit/security/code-scanning/5)).

## Approach

While the alert is valid for only 1 of the 3 unpinned actions, we should pin the actions anyway to silence future CodeQL alerts from clones of this repo.

I have manually reviewed the pinned `xom9ikk/dotenv@v2` to ensure that it is not malicious.

## Risks

The pinned versions may not have the latest features/bugfixes (most relevant for `chromaui/action`), potentially causing issues down the road.

## Testing

The workflow will be run below.