### PR TITLE
fix: limit permissions for github workflows

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -14,6 +14,9 @@ on:
 # List of jobs
 jobs:
   chromatic-deployment:
+    permissions:
+      contents: read
+      checks: write
     # Operating System
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
   checks: write
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
 jobs:
   install:
     name: Install dependencies
@@ -66,6 +71,10 @@ jobs:
       - install
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup


### PR DESCRIPTION
## Context

CodeQL generated alerts for lack of explicit permissions in github workflows.
This is yet another level of hardening, but it is not strictly necessary for us to do so.
However, it is indeed good practice and it does not hurt to add it into the workflow.

See alerts ([6](https://github.com/opengovsg/starter-kit/security/code-scanning/6), [7](https://github.com/opengovsg/starter-kit/security/code-scanning/7), [8](https://github.com/opengovsg/starter-kit/security/code-scanning/8), [9](https://github.com/opengovsg/starter-kit/security/code-scanning/9), [10](https://github.com/opengovsg/starter-kit/security/code-scanning/10), [11](https://github.com/opengovsg/starter-kit/security/code-scanning/11))

## Approach

For both workflows:
- `checks: write` is required to write check outcome in PRs.
- `contents: read` is required to read repo contents.

However, `end-to-end` tests require `actions: write` to perform `actions/upload-artifact@v4`.

## Risks & Testing

Workflow will be run below
