### PR TITLE
feat: replace redirect url pattern with route key pattern

### DIFF
--- a/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
+++ b/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
@@ -1,45 +1,39 @@
-import { useMemo, type PropsWithChildren } from 'react'
+import { useEffect, type PropsWithChildren } from 'react'
 import { useRouter } from 'next/router'
 
-import { appendWithRedirect } from '~/utils/url'
+import { appendWithRedirectRouteKey } from '~/utils/url'
 import { useLoginState } from '~/features/auth'
-import { SIGN_IN } from '~/lib/routes'
-import { callbackUrlSchema } from '~/schemas/url'
+import { SIGN_IN, type AllRoutes } from '~/lib/routes'
 import { FullscreenSpinner } from '../FullscreenSpinner'
 
 interface EnforceLoginStatePageWrapperProps {
   /**
-   * Route to redirect to when user is not authenticated. Defaults to
-   * `SIGN_IN` route if not provided.
+   * Route to redirect to after user is authenticated. Defaults to
+   * `HOME` route if not provided.
    */
-  redirectTo?: string
+  routeKeyAfterSignIn?: keyof typeof AllRoutes
 }
 
 const Redirect = ({
-  redirectTo = SIGN_IN,
+  routeKeyAfterSignIn: redirectTo = 'HOME',
 }: EnforceLoginStatePageWrapperProps) => {
   const router = useRouter()
-  const redirectUrl = useMemo(() => {
-    if (typeof window === 'undefined') return '/'
-    const { pathname, search, hash } = window.location
-    return `${pathname}${search}${hash}`
-  }, [])
 
-  void router.replace(
-    callbackUrlSchema.parse(appendWithRedirect(redirectTo, redirectUrl)),
-  )
+  useEffect(() => {
+    void router.replace(appendWithRedirectRouteKey(SIGN_IN, redirectTo))
+  }, [router, redirectTo])
 
   return <FullscreenSpinner />
 }
 
 /**
  * Page wrapper that renders children only if the login state localStorage flag has been set.
- * Otherwise, will redirect to the route passed into the `redirectTo` prop.
+ * Otherwise, will redirect to SIGN_IN, which will redirect to route key passed into the `routeKeyAfterSignIn` prop.
  *
  * @note 🚨 There is no authentication being performed by this component. This component is merely a wrapper that checks for the presence of the login flag in localStorage. This means that a user could add the flag and bypass the check. Any page children that require authentication should also perform authentication checks in that page itself!
  */
 export const EnforceLoginStatePageWrapper = ({
-  redirectTo = SIGN_IN,
+  routeKeyAfterSignIn = 'HOME',
   children,
 }: PropsWithChildren<EnforceLoginStatePageWrapperProps>): React.ReactElement => {
   const { hasLoginStateFlag } = useLoginState()
@@ -48,5 +42,5 @@ export const EnforceLoginStatePageWrapper = ({
     return <>{children}</>
   }
 
-  return <Redirect redirectTo={redirectTo} />
+  return <Redirect routeKeyAfterSignIn={routeKeyAfterSignIn} />
 }

--- a/src/components/AuthWrappers/PublicPageWrapper.tsx
+++ b/src/components/AuthWrappers/PublicPageWrapper.tsx
@@ -1,13 +1,13 @@
 import { type PropsWithChildren } from 'react'
 import { useRouter } from 'next/router'
 
-import { CALLBACK_URL_KEY } from '~/constants/params'
+import { getRedirectRoute, resolveRouteKey } from '~/utils/url'
 import { useLoginState } from '~/features/auth'
-import { callbackUrlSchema } from '~/schemas/url'
+import { type AllRoutes } from '~/lib/routes'
 import { FullscreenSpinner } from '../FullscreenSpinner'
 
 type PublicPageWrapperProps =
-  | { strict: true; redirectUrl?: string }
+  | { strict: true; redirectRouteKey?: keyof typeof AllRoutes }
   | { strict: false }
 
 /**
@@ -24,12 +24,10 @@ export const PublicPageWrapper = ({
   const { hasLoginStateFlag } = useLoginState()
 
   if (hasLoginStateFlag && rest.strict) {
-    if (rest.redirectUrl) {
-      void router.replace(callbackUrlSchema.parse(rest.redirectUrl))
+    if (rest.redirectRouteKey) {
+      void router.replace(resolveRouteKey(rest.redirectRouteKey))
     } else {
-      void router.replace(
-        callbackUrlSchema.parse(router.query[CALLBACK_URL_KEY]),
-      )
+      void router.replace(getRedirectRoute(router.query))
     }
     return <FullscreenSpinner />
   }

--- a/src/constants/params.ts
+++ b/src/constants/params.ts
@@ -1,1 +1,1 @@
-export const CALLBACK_URL_KEY = 'callbackUrl' as const
+export const REDIRECT_ROUTE_KEY = 'redirectRouteKey' as const

--- a/src/features/sign-in/components/EmailLogin/VerificationInput.tsx
+++ b/src/features/sign-in/components/EmailLogin/VerificationInput.tsx
@@ -17,12 +17,11 @@ import { Controller } from 'react-hook-form'
 import { useInterval } from 'usehooks-ts'
 
 import { trpc } from '~/utils/trpc'
-import { CALLBACK_URL_KEY } from '~/constants/params'
+import { getRedirectRoute } from '~/utils/url'
 import { useLoginState } from '~/features/auth'
 import { OTP_LENGTH } from '~/lib/auth'
 import { useZodForm } from '~/lib/form'
 import { emailVerifyOtpSchema } from '~/schemas/auth/email/sign-in'
-import { callbackUrlSchema } from '~/schemas/url'
 import { useSignInContext } from '../SignInContext'
 import { ResendOtpButton } from './ResendOtpButton'
 
@@ -61,7 +60,7 @@ export const VerificationInput = (): JSX.Element | null => {
       await utils.me.get.invalidate()
       // accessing router.query values returns decoded URI params automatically,
       // so there's no need to call decodeURIComponent manually when accessing the callback url.
-      await router.push(callbackUrlSchema.parse(router.query[CALLBACK_URL_KEY]))
+      await router.push(getRedirectRoute(router.query))
     },
     onError: (error) => {
       switch (error.message) {

--- a/src/features/sign-in/components/SgidCallback.tsx
+++ b/src/features/sign-in/components/SgidCallback.tsx
@@ -2,9 +2,10 @@ import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 
 import { trpc } from '~/utils/trpc'
+import { appendWithRedirectRouteKey } from '~/utils/url'
 import { FullscreenSpinner } from '~/components/FullscreenSpinner'
 import { useLoginState } from '~/features/auth'
-import { callbackUrlSchema } from '~/schemas/url'
+import { SIGN_IN, SIGN_IN_SELECT_PROFILE } from '~/lib/routes'
 
 /**
  * This component is responsible for handling the callback from the SGID login.
@@ -19,27 +20,29 @@ export const SgidCallback = (): JSX.Element => {
     query: { code, state },
   } = router
 
-  const [{ redirectUrl, selectProfileStep }] =
-    trpc.auth.sgid.callback.useSuspenseQuery(
-      { code: String(code), state: String(state) },
-      { staleTime: Infinity },
-    )
+  const [response] = trpc.auth.sgid.callback.useSuspenseQuery(
+    { code: String(code), state: String(state) },
+    { staleTime: Infinity },
+  )
 
   useEffect(() => {
-    if (!selectProfileStep) {
-      setHasLoginStateFlag()
+    if (!response.success) {
+      void router.replace(
+        `${SIGN_IN}?${new URLSearchParams({ error: response.reason })}`,
+      )
+    } else {
+      const { selectProfileStep, landingRouteKey } = response.data
+      if (!selectProfileStep) {
+        setHasLoginStateFlag()
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        utils.me.get.invalidate()
+      }
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      utils.me.get.invalidate()
+      router.replace(
+        appendWithRedirectRouteKey(SIGN_IN_SELECT_PROFILE, landingRouteKey),
+      )
     }
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    router.replace(callbackUrlSchema.parse(redirectUrl))
-  }, [
-    redirectUrl,
-    router,
-    selectProfileStep,
-    setHasLoginStateFlag,
-    utils.me.get,
-  ])
+  }, [response, router, setHasLoginStateFlag, utils.me.get])
 
   return <FullscreenSpinner />
 }

--- a/src/features/sign-in/components/SgidErrorFallback/SgidErrorFallback.tsx
+++ b/src/features/sign-in/components/SgidErrorFallback/SgidErrorFallback.tsx
@@ -4,24 +4,23 @@ import { type FallbackProps } from 'react-error-boundary'
 import { z } from 'zod'
 
 import { safeSchemaJsonParse } from '~/utils/zod'
-import { HOME } from '~/lib/routes'
-import { callbackUrlSchema } from '~/schemas/url'
+import { routeKeySchema } from '~/schemas/url'
 import { SgidErrorModal } from './SgidErrorModal'
 
 export const SgidErrorFallback: ComponentType<FallbackProps> = ({ error }) => {
   const router = useRouter()
-  const redirectUrl = useMemo(() => {
+  const routeKey = useMemo(() => {
     const parsed = safeSchemaJsonParse(
       z.object({
-        landingUrl: callbackUrlSchema,
+        landingRouteKey: routeKeySchema,
       }),
       String(router.query.state),
     )
     if (parsed.success) {
-      return parsed.data.landingUrl.href
+      return parsed.data.landingRouteKey
     }
-    return HOME
+    return 'HOME'
   }, [router.query.state])
 
-  return <SgidErrorModal message={error.message} redirectUrl={redirectUrl} />
+  return <SgidErrorModal message={error.message} redirectRouteKey={routeKey} />
 }

--- a/src/features/sign-in/components/SgidErrorFallback/SgidErrorModal.tsx
+++ b/src/features/sign-in/components/SgidErrorFallback/SgidErrorModal.tsx
@@ -12,18 +12,18 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 
-import { appendWithRedirect } from '~/utils/url'
+import { appendWithRedirectRouteKey } from '~/utils/url'
 import { SGID } from '~/lib/errors/auth.sgid'
-import { SIGN_IN } from '~/lib/routes'
+import { SIGN_IN, type AllRoutes } from '~/lib/routes'
 
 interface SgidErrorModalProps {
   message: string
-  redirectUrl: string
+  redirectRouteKey: keyof typeof AllRoutes
 }
 
 export const SgidErrorModal = ({
   message,
-  redirectUrl,
+  redirectRouteKey,
 }: SgidErrorModalProps) => {
   const { onClose } = useDisclosure()
   const modalSize = useBreakpointValue({
@@ -47,8 +47,8 @@ export const SgidErrorModal = ({
   }, [message])
 
   const backToLoginLink = useMemo(() => {
-    return appendWithRedirect(SIGN_IN, redirectUrl)
-  }, [redirectUrl])
+    return appendWithRedirectRouteKey(SIGN_IN, redirectRouteKey)
+  }, [redirectRouteKey])
 
   return (
     <Modal isOpen onClose={onClose} size={modalSize}>

--- a/src/features/sign-in/components/SgidLogin/SgidLoginButton.tsx
+++ b/src/features/sign-in/components/SgidLogin/SgidLoginButton.tsx
@@ -3,23 +3,20 @@ import { Box, Divider, Flex, HStack, Stack, Text } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 
 import { trpc } from '~/utils/trpc'
-import { getRedirectUrl } from '~/utils/url'
+import { getRedirectRouteKey } from '~/utils/url'
 import { SingpassFullLogo } from '~/components/Svg/SingpassFullLogo'
-import { callbackUrlSchema } from '~/schemas/url'
 
 export const SgidLoginButton = (): JSX.Element | null => {
   const router = useRouter()
   const sgidLoginMutation = trpc.auth.sgid.login.useMutation({
     onSuccess: async ({ redirectUrl }) => {
-      await router.push(redirectUrl)
+      window.location.href = redirectUrl
     },
   })
 
-  const landingUrl = callbackUrlSchema.parse(getRedirectUrl(router.query)).href
-
   const handleSgidLogin = () => {
     return sgidLoginMutation.mutate({
-      landingUrl,
+      landingRouteKey: getRedirectRouteKey(router.query),
     })
   }
 

--- a/src/features/sign-in/components/SgidProfileList/SgidProfileList.tsx
+++ b/src/features/sign-in/components/SgidProfileList/SgidProfileList.tsx
@@ -3,10 +3,10 @@ import { useRouter } from 'next/router'
 import { Divider, Stack } from '@chakra-ui/react'
 
 import { trpc } from '~/utils/trpc'
-import { CALLBACK_URL_KEY } from '~/constants/params'
+import { REDIRECT_ROUTE_KEY } from '~/constants/params'
 import { useLoginState } from '~/features/auth'
 import { withSuspense } from '~/hocs/withSuspense'
-import { callbackUrlSchema } from '~/schemas/url'
+import { routeKeySchema } from '~/schemas/url'
 import { SgidProfileItem } from './SgidProfileItem'
 import { SgidProfileListSkeleton } from './SgidProfileListSkeleton'
 
@@ -23,7 +23,7 @@ const SuspendableSgidProfileList = (): JSX.Element => {
       setHasLoginStateFlag()
       await utils.me.get.invalidate()
       await router.replace(
-        callbackUrlSchema.parse(router.query[CALLBACK_URL_KEY]),
+        routeKeySchema.parse(router.query[REDIRECT_ROUTE_KEY]),
       )
     },
   })

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,6 +1,14 @@
 export const SIGN_IN = '/sign-in'
-export const SIGN_IN_SELECT_PROFILE_SUBROUTE = '/select-profile'
+export const SIGN_IN_SELECT_PROFILE = '/sign-in/select-profile'
 
 export const HOME = '/home'
 export const PROFILE = '/profile'
 export const SETTINGS_PROFILE = '/settings/profile'
+
+export const AllRoutes = {
+  SIGN_IN,
+  SIGN_IN_SELECT_PROFILE,
+  HOME,
+  PROFILE,
+  SETTINGS_PROFILE,
+}

--- a/src/schemas/url.ts
+++ b/src/schemas/url.ts
@@ -2,7 +2,8 @@ import { createUrlSchema } from '@opengovsg/starter-kitty-validators/url'
 import { z } from 'zod'
 
 import { getBaseUrl } from '~/utils/getBaseUrl'
-import { HOME } from '~/lib/routes'
+import { zodEnumFromObjKeys } from '~/utils/zod'
+import { AllRoutes, HOME } from '~/lib/routes'
 
 const baseUrl = new URL(getBaseUrl())
 
@@ -14,7 +15,10 @@ const urlSchema = createUrlSchema({
   },
 })
 
-export const callbackUrlSchema = z
+/**
+ * Zod schema for validating internal (same-app) URLs
+ */
+export const appUrlSchema = z
   .string()
   .optional()
   .default(HOME)
@@ -30,3 +34,10 @@ export const callbackUrlSchema = z
     }
   })
   .catch(new URL(HOME, baseUrl.origin))
+
+/**
+ * Zod schema for validating routeKeys
+ */
+export const routeKeySchema = zodEnumFromObjKeys(AllRoutes)
+  .optional()
+  .default('HOME')

--- a/src/utils/zod.ts
+++ b/src/utils/zod.ts
@@ -29,3 +29,31 @@ export const safeSchemaJsonParse = <T extends z.ZodTypeAny>(
     return { success: false, error: new Error(`Unknown JSON parse error`) }
   }
 }
+
+/**
+ * Creates a Zod enum schema from the keys of an object.
+ */
+// https://github.com/colinhacks/zod/discussions/839#discussioncomment-10651593
+export const zodEnumFromObjKeys = <T extends Record<string, U>, U>(obj: T) => {
+  const keys = Object.keys(obj) as Extract<keyof T, string>[]
+  return z.enum(
+    keys as [Extract<keyof T, string>, ...Extract<keyof T, string>[]],
+  )
+}
+
+/**
+ * Creates a Zod schema for an API response object discriminated on `success`
+ * The schema is {success: true, data: T} | {success: false, reason: string}
+ */
+export const createResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) => {
+  return z.discriminatedUnion('success', [
+    z.object({
+      success: z.literal(true),
+      data: dataSchema,
+    }),
+    z.object({
+      success: z.literal(false),
+      reason: z.string(),
+    }),
+  ])
+}


### PR DESCRIPTION
## Context

Due to yet another `open redirect` VAPT finding (`care360: GTA-55-008`), it has proved to be very challenging to validate the `callbackUrl` parameter.

## Approach

This PR completely removes the `callbackUrl` parameter in favor of the `redirectRouteKey` parameter.

In all situations where we redirect ,`redirectRouteKey` is first validated to be `keyof AllRoutes`, falling back to `HOME` when invalid. (`AllRoutes` is a dict with all the routes in the app).

Then we resolve the `route key` to the actual route.

## How to read this PR

Please look at all the utilities `lib/` `schemas/` `utils/` first to familiarize with the constructs that enable this route key pattern.

Then evaluate the components involved in the email login flow followed by the SGID login flow.

Finally you can evaluate utility component wrappers under `AuthWrappers/`

## Risks and Testing

I will manually test the vercel deployment to ensure that both login flows still work as intended.