### PR TITLE
chore: bump starter-kitty-validators to v1.2.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5904,9 +5904,9 @@
       }
     },
     "node_modules/@opengovsg/starter-kitty-validators": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@opengovsg/starter-kitty-validators/-/starter-kitty-validators-1.2.10.tgz",
-      "integrity": "sha512-AnO/bDEWbuUfvK6ED6xzt4pYn2/oe0A9PiVXcufGvvFskqsml2awzAu1cYLCq4tdgQGrvQizVBKZ+deKdfhbmg==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@opengovsg/starter-kitty-validators/-/starter-kitty-validators-1.2.11.tgz",
+      "integrity": "sha512-p+S6f44cIx3FiOfeLMWQN5igz3AUDVNnwD1mNkFm50ijH/xmRDJ4O/W1eG8yrLCm2zZf8EYSvmRKVzv4ukUCow==",
       "dependencies": {
         "email-addresses": "^5.0.0",
         "zod": "^3.23.8",
@@ -25893,9 +25893,9 @@
       }
     },
     "@opengovsg/starter-kitty-validators": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@opengovsg/starter-kitty-validators/-/starter-kitty-validators-1.2.10.tgz",
-      "integrity": "sha512-AnO/bDEWbuUfvK6ED6xzt4pYn2/oe0A9PiVXcufGvvFskqsml2awzAu1cYLCq4tdgQGrvQizVBKZ+deKdfhbmg==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@opengovsg/starter-kitty-validators/-/starter-kitty-validators-1.2.11.tgz",
+      "integrity": "sha512-p+S6f44cIx3FiOfeLMWQN5igz3AUDVNnwD1mNkFm50ijH/xmRDJ4O/W1eG8yrLCm2zZf8EYSvmRKVzv4ukUCow==",
       "requires": {
         "email-addresses": "^5.0.0",
         "zod": "^3.23.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@hookform/resolvers": "^3.3.4",
         "@opengovsg/design-system-react": "^1.24.0",
         "@opengovsg/sgid-client": "^2.3.0",
-        "@opengovsg/starter-kitty-validators": "^1.2.10",
+        "@opengovsg/starter-kitty-validators": "^1.2.11",
         "@prisma/client": "^5.7.1",
         "@sendgrid/mail": "^8.1.3",
         "@tanstack/react-query": "^4.36.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@hookform/resolvers": "^3.3.4",
     "@opengovsg/design-system-react": "^1.24.0",
     "@opengovsg/sgid-client": "^2.3.0",
-    "@opengovsg/starter-kitty-validators": "^1.2.10",
+    "@opengovsg/starter-kitty-validators": "^1.2.11",
     "@prisma/client": "^5.7.1",
     "@sendgrid/mail": "^8.1.3",
     "@tanstack/react-query": "^4.36.1",


### PR DESCRIPTION
## Context
`starter-kitty-validators@1.2.11` contains a patch for a NextJS open redirect via interception routes.
This change breaks routes containing the following pattern `(.)` or `(..)` or `(...)` or `(..)(..)`

## Risks
`starter-kit` does not use any routes with the aforementioned pattern, so there is no risk of breaking anything.