### PR TITLE
feat: disable trpc batching

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,7 +13,7 @@ import {
   type ReactRenderer,
 } from '@storybook/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { httpBatchLink } from '@trpc/client'
+import { httpLink } from '@trpc/client'
 import { createTRPCReact } from '@trpc/react-query'
 import { format } from 'date-fns/format'
 import merge from 'lodash/merge'
@@ -71,7 +71,7 @@ const SetupDecorator: Decorator = (story) => {
   )
   const [trpcClient] = useState(() =>
     trpc.createClient({
-      links: [httpBatchLink({ url: '' })],
+      links: [httpLink({ url: '' })],
       transformer: superjson,
     }),
   )

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -20,11 +20,11 @@ export default trpcNext.createNextApiHandler({
       ctx?.session?.destroy()
     }
   },
-  /**
-   * Enable query batching
-   */
   batching: {
-    enabled: true,
+    /**
+     * Disable query batching for better logging (and since we mostly self-host the app without Serverless)
+     */
+    enabled: false,
   },
   /**
    * @link https://trpc.io/docs/caching#api-response-caching

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -1,6 +1,6 @@
 import { type NextPageContext } from 'next'
 import {
-  httpBatchLink,
+  httpLink,
   loggerLink,
   TRPCClientError,
   type TRPCLink,
@@ -156,7 +156,7 @@ export const trpc = createTRPCNext<
             process.env.NODE_ENV === 'development' ||
             (opts.direction === 'down' && opts.result instanceof Error),
         }),
-        httpBatchLink({
+        httpLink({
           url: `${getBaseUrl()}/api/trpc`,
           /**
            * Provide a function that will invoke the current global


### PR DESCRIPTION
Context
https://opengovproducts.slack.com/archives/C055FUACLJU/p1737346863461179

This pull request includes several changes to the TRPC client configuration to improve logging and simplify the codebase. The most important changes involve replacing the `httpBatchLink` with `httpLink` and disabling query batching.

Changes to TRPC client configuration:

* [`.storybook/preview.tsx`](diffhunk://#diff-e201de4e2ea4ee79f492c0495d7f3fce6389034fe26bfb8f3c877f8c03edf914L16-R16): Replaced `httpBatchLink` with `httpLink` in the import statement and in the `SetupDecorator` function. [[1]](diffhunk://#diff-e201de4e2ea4ee79f492c0495d7f3fce6389034fe26bfb8f3c877f8c03edf914L16-R16) [[2]](diffhunk://#diff-e201de4e2ea4ee79f492c0495d7f3fce6389034fe26bfb8f3c877f8c03edf914L74-R74)
* `src/pages/api/trpc/[trpc].ts`: Disabled query batching for better logging by setting `enabled` to `false` in the `batching` configuration. ([src/pages/api/trpc/[trpc].tsR23-R27](diffhunk://#diff-4832edba35ca7cf0f17b373fcce4e76e270583ffe43e00b87d62861f8129792dR23-R27))
* [`src/utils/trpc.ts`](diffhunk://#diff-ae3fd21dfd357c787342d919322fd563e7a87d3f1d177222e5564273b4b888a2L3-R3): Replaced `httpBatchLink` with `httpLink` in the import statement and in the `trpc` client creation. [[1]](diffhunk://#diff-ae3fd21dfd357c787342d919322fd563e7a87d3f1d177222e5564273b4b888a2L3-R3) [[2]](diffhunk://#diff-ae3fd21dfd357c787342d919322fd563e7a87d3f1d177222e5564273b4b888a2L159-R159)