### PR TITLE
fix: add next keep alive timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prebuild": "run-s generate migrate",
     "build": "next build",
     "build:theme": "npx chakra-cli tokens src/theme/index.ts",
-    "start": "next start",
+    "start": "next start --keepAliveTimeout 70000",
     "lint": "eslint --report-unused-disable-directives --report-unused-disable-directives .",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --check \"**/*.{js,cjs,mjs,ts,tsx,md,json}\" --ignore-path .prettierignore --config .prettierrc.cjs",


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Users may face unexpected 502 Gateway Errors when ALB-fronted NodeJS (and NextJS) applications use the default 5 second keep-alive timeout.

The default AWS ALB keep-alive timeout is defined as 60 seconds, which means requests may be proxied through a prematurely terminated connection.

This issue has also been noticed (and fixed) in other OGP products, including:

- Downstream products forked from starter-kit, e.g. [Armoury](https://github.com/opengovsg/armoury/pull/1008)
- Other products using their own stack, e.g. [Health Appointment System](https://github.com/opengovsg/phas/pull/2191/files)

## Solution

_How did you solve the problem?_

> [!NOTE]
> Fixing this at the starter-kit template level allows new products to automatically benefit from others' experience.

**Bug Fixes**:

- Increase the [keep-alive timeout for NextJS to 70 seconds](https://nextjs.org/docs/app/api-reference/cli/next#configuring-a-timeout-for-downstream-proxies), greater than the ALB timeout.

## Tests

_What tests should be run to confirm functionality?_

No changes to business logic are expected. We should verify that:
- serverless deployments (e.g. Vercel) behave correctly
- containerised deployments (e.g. AWS ECS) behave correctly

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

No changes to deployment characteristics are expected.
