### PR TITLE
fix: use monotonic clock for measuring spans

### DIFF
--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -45,14 +45,14 @@ const t = initTRPC.context<Context>().create({
 // Setting outer context with tRPC will not get us correct path during request batching,
 // only by setting logger context in the middleware do we get the exact path to log
 const loggerMiddleware = t.middleware(async ({ path, next, ctx, type }) => {
-  const start = Date.now()
+  const start = performance.now()
   const logger = createBaseLogger({ path, clientIp: getIP(ctx.req) })
 
   const result = await next({
     ctx: { logger },
   })
 
-  const durationInMs = Date.now() - start
+  const durationInMs = Math.round(performance.now() - start)
 
   if (result.ok) {
     logger.info({ durationInMs }, `[${type}]: ${path} - ${durationInMs}ms - OK`)


### PR DESCRIPTION
## Context

[Good pre-read](https://blog.insiderattack.net/how-not-to-measure-time-in-programming-11089d546180)

Tracking of spans might be inaccurate as a time-of-day clock is subject to moving forward or backward due to NTP stepping and is subject to leap second adjustments. Using a monotonic clock allows us to have a more accurate measurement of elapsed time on a single node. 

Did a similar fix for [ASG](https://github.com/opengovsg/activesg/pull/2664) 