### PR TITLE
chore(ci): pin chromaui/action to commit SHA

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -46,7 +46,7 @@ jobs:
         uses: ./tooling/github/setup
       - name: Publish to Chromatic
         if: env.CHROMATIC_WEB_PROJECT_TOKEN != ''
-        uses: chromaui/action@latest
+        uses: chromaui/action@e3eb8ec36101d8f0253c7c3ae66e5a2b4e2197ba # v16.10.0
         with:
           workingDir: apps/web
           storybookBaseDir: apps/web


### PR DESCRIPTION
## Summary

- Replaces `chromaui/action@latest` in `.github/workflows/chromatic.yml` with the v16.10.0 commit SHA (`e3eb8ec36101d8f0253c7c3ae66e5a2b4e2197ba`).
- The `latest` tag is mutable — whoever controls it upstream runs in our CI on every push to `main` and every non-fork PR, with access to `CHROMATIC_WEB_PROJECT_TOKEN` and the workflow's `GITHUB_TOKEN`.
- Brings this action in line with the SHA-pinning convention already used for `dorny/paths-filter` (chromatic.yml:26) and `datadog/test-visibility-github-action` (ci.yml).

## Risk

- Trigger is `pull_request` (not `pull_request_target`), so forked PRs do not have access to secrets — but pushes to `main` and same-repo PRs do.
- `GITHUB_TOKEN` is read-only (`contents: read`, `pull-requests: read`), limiting compromise blast radius to the Chromatic token (snapshot poisoning, baseline tampering).

## Follow-up

- Consider adding a `github-actions` ecosystem entry to `.github/dependabot.yml` so this stays current automatically.

## Test plan

- [ ] Chromatic workflow runs successfully on this PR
- [ ] Visual snapshots upload as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)