### PR TITLE
test(me-router): assert UNAUTHORIZED via rejects matcher

### DIFF
--- a/apps/web/src/server/api/routers/__tests__/me.router.spec.ts
+++ b/apps/web/src/server/api/routers/__tests__/me.router.spec.ts
@@ -1,4 +1,3 @@
-import { TRPCError } from '@trpc/server'
 import { resetTables } from '~tests/db/utils'
 import { createTestCaller, createTestContext } from '~tests/trpc'
 
@@ -14,12 +13,10 @@ describe('meRouter', () => {
       const ctx = createTestContext(undefined)
       const caller = createTestCaller(ctx)
 
-      try {
-        await caller.me.get()
-      } catch (error) {
-        expect(error).toBeInstanceOf(TRPCError)
-        expect((error as TRPCError).code).toEqual('UNAUTHORIZED')
-      }
+      await expect(caller.me.get()).rejects.toMatchObject({
+        name: 'TRPCError',
+        code: 'UNAUTHORIZED',
+      })
     })
 
     it('should return user data when authenticated', async () => {


### PR DESCRIPTION
## Summary
- The `should throw UNAUTHORIZED error when user is not authenticated` test in `me.router.spec.ts` wrapped `caller.me.get()` in a try/catch with no `expect.assertions(...)` declaration. Jest treats a test with no failed expectations as passing, so if the auth guard ever regressed (e.g. procedure returned `null` instead of throwing `TRPCError`), the test would silently pass with zero assertions and mask the regression.
- Replaced the try/catch with `await expect(caller.me.get()).rejects.toMatchObject({ name: 'TRPCError', code: 'UNAUTHORIZED' })`, which fails if the procedure resolves instead of throwing.
- Removed the now-unused `TRPCError` import.

## Test plan
- [ ] `pnpm test apps/web/src/server/api/routers/__tests__/me.router.spec.ts` passes
- [ ] Temporarily make `me.get` return `null` for unauthenticated callers and confirm this test now fails (was previously passing silently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)