### PR TITLE
fix(ui): honor `icon={null}` contract in Infobox

### DIFF
--- a/packages/ui/src/infobox/infobox.tsx
+++ b/packages/ui/src/infobox/infobox.tsx
@@ -35,8 +35,12 @@ export const Infobox = (originalProps: InfoboxProps) => {
   const styles = infoboxStyles(variantProps)
 
   const icon = useMemo(() => {
+    // `null` hides the icon; `undefined` falls through to the variant default.
+    if (props.icon === null) {
+      return null
+    }
     const iconClassName = styles.icon({ className: props.classNames?.icon })
-    if (props.icon) {
+    if (props.icon !== undefined) {
       return <div className={iconClassName}>{props.icon}</div>
     }
     switch (variantProps.variant) {


### PR DESCRIPTION
## Summary
- `packages/ui/src/infobox/infobox.tsx` documented that `icon={null}` should hide the icon while `undefined` should fall back to the variant default, but `if (props.icon)` treated both the same — so `null` still rendered the default icon.
- Replace the truthy check with explicit `=== null` / `!== undefined` branches so the published contract holds.

## Test plan
- [ ] `<Infobox variant="info">` (no `icon` prop) still renders the default info icon
- [ ] `<Infobox variant="error" icon={null}>` renders with no icon
- [ ] `<Infobox variant="success" icon={<CustomIcon />}>` renders the custom icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)