### PR TITLE
fix(logging): preserve error.message and name in logs

### DIFF
--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -12,6 +12,8 @@
     "dev": "tsc",
     "format": "oxfmt --ignore-path ../../.gitignore .",
     "lint": "oxlint .",
+    "test": "vitest",
+    "test:ci": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
@@ -27,6 +29,7 @@
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "oxlint-tsgolint": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:vitest"
   }
 }

--- a/packages/logging/src/__tests__/logger.spec.ts
+++ b/packages/logging/src/__tests__/logger.spec.ts
@@ -1,0 +1,76 @@
+import { CustomLogger } from '../logger'
+
+const makeMockLogger = () => ({
+  notice: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  alert: vi.fn(),
+  critical: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  fatal: vi.fn(),
+})
+
+describe('CustomLogger', () => {
+  describe('formatLogWithErrors', () => {
+    it.each(['notice', 'warn', 'error', 'alert', 'critical'] as const)(
+      'preserves error.message and error.name on %s',
+      (level) => {
+        const mock = makeMockLogger()
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const logger = new CustomLogger(mock as any)
+        const err = new Error('boom')
+
+        logger[level]({
+          message: 'something failed',
+          action: 'test',
+          error: err,
+        })
+
+        expect(mock[level]).toHaveBeenCalledTimes(1)
+        const [payload, message] = mock[level].mock.calls[0] as [
+          { error: { message: string; name: string; stack?: string } },
+          string,
+        ]
+        expect(message).toBe('something failed')
+        expect(payload.error.message).toBe('boom')
+        expect(payload.error.name).toBe('Error')
+        expect(payload.error.stack).toBeDefined()
+      }
+    )
+
+    it('preserves custom enumerable props and cause on Error subclasses', () => {
+      class HttpError extends Error {
+        status: number
+        constructor(message: string, status: number, options?: ErrorOptions) {
+          super(message, options)
+          this.name = 'HttpError'
+          this.status = status
+        }
+      }
+
+      const mock = makeMockLogger()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const logger = new CustomLogger(mock as any)
+      const cause = new Error('upstream timeout')
+      const err = new HttpError('bad gateway', 502, { cause })
+
+      logger.error({ message: 'req failed', action: 'test', error: err })
+
+      const [payload] = mock.error.mock.calls[0] as [
+        {
+          error: {
+            message: string
+            name: string
+            status: number
+            cause: unknown
+          }
+        },
+      ]
+      expect(payload.error.message).toBe('bad gateway')
+      expect(payload.error.name).toBe('HttpError')
+      expect(payload.error.status).toBe(502)
+      expect(payload.error.cause).toBe(cause)
+    })
+  })
+})

--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -230,7 +230,15 @@ export class CustomLogger<
           ...rest,
           ...merged,
           context,
-          error: { ...error, stack: error.stack, cause: error.cause },
+          // `message`, `name`, and `stack` are non-enumerable on Error, so
+          // spreading alone drops them — copy them explicitly.
+          error: {
+            ...error,
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
+            cause: error.cause,
+          },
         },
         message
       )

--- a/packages/logging/tsconfig.json
+++ b/packages/logging/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@acme/tsconfig/compiled-package.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
   "include": ["src"],
   "exclude": ["node_modules"]
 }

--- a/packages/logging/vitest.config.ts
+++ b/packages/logging/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,6 +516,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: catalog:vitest
+        version: 4.0.8(@types/node@24.10.4)(@vitest/browser-playwright@4.0.8)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.7(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.2)
 
   packages/redis:
     dependencies:
@@ -6226,10 +6229,6 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -6994,10 +6993,6 @@ packages:
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -12121,7 +12116,7 @@ snapshots:
       '@vitest/spy': 4.0.8
       '@vitest/utils': 4.0.8
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/mocker@4.0.8(msw@2.12.7(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.2(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2))':
     dependencies:
@@ -12152,7 +12147,7 @@ snapshots:
 
   '@vitest/pretty-format@4.0.8':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/runner@4.0.10':
     dependencies:
@@ -14226,8 +14221,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pino-abstract-transport@2.0.0:
@@ -15384,11 +15377,6 @@ snapshots:
 
   tinyexec@1.0.2: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -15405,8 +15393,7 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
-  tinyrainbow@3.1.0:
-    optional: true
+  tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
 
@@ -15671,12 +15658,12 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -15710,12 +15697,12 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Summary
- `Error.prototype.message`, `name`, and `stack` are non-enumerable, so `{ ...error, stack, cause }` in `formatLogWithErrors` was silently dropping `message` and `name` from every `notice`/`warn`/`error`/`alert`/`critical` payload that received an `Error` instance.
- Fix: copy `name` and `message` explicitly alongside `stack` and `cause`. Added a short comment so the next person doesn't "simplify" it back.
- Bootstrapped vitest in `@acme/logging` (no tests existed) and added regression tests covering every error-level method plus an `Error` subclass with `cause` and a custom enumerable field.

## Test plan
- [x] `pnpm turbo test:ci --filter=@acme/logging` — 6/6 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)