### PR TITLE
docs: update README files to reflect current codebase state

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A technical kit to quickly build new products from
 
 - 🗼 Monorepo setup with [Turborepo](https://turborepo.com)
 - 🧙‍♂️ E2E typesafety with [tRPC v11](https://trpc.io)
-- ⚡ Full-stack React with [Next.js v15](https://nextjs.org)
+- ⚡ Full-stack React with [Next.js v16](https://nextjs.org)
 - 🌈 Database with [Prisma](https://www.prisma.io/)
 - ⚙️ VSCode extensions
 - 🎨 Oxlint + Oxfmt
@@ -33,18 +33,30 @@ A technical kit to quickly build new products from
   └─ Oxfmt formatter configuration
 apps
   └─ web
-      ├─ Next.js 15
+      ├─ Next.js 16
       ├─ React 19
       ├─ Tailwind CSS v4
       └─ E2E Typesafe API Server & Client
 packages
+  ├─ common
+  │   └─ Shared utilities and types
   ├─ db
-  │   └─ Typesafe db calls using Prisma
-  └─ ui
-      └─ Start of a UI package for the webapp using react-aria-components + @opengovsg/oui
+  │   └─ Typesafe db calls using Prisma + Kysely
+  ├─ logging
+  │   └─ Shared logging utilities
+  ├─ redis
+  │   └─ Redis client and utilities
+  ├─ ui
+  │   └─ UI component library using react-aria-components + @opengovsg/oui
+  └─ validators
+      └─ Shared Zod validation schemas
 tooling
+  ├─ github
+  │   └─ Shared GitHub Actions workflows
   ├─ oxlint
   │   └─ shared Oxlint configuration
+  ├─ storybook
+  │   └─ shared Storybook configuration
   ├─ tailwind
   │   └─ shared tailwind theme and configuration
   └─ typescript
@@ -73,7 +85,7 @@ grep -rl '@acme' --exclude='*.md' --exclude-dir='.git' --exclude-dir='node_modul
 grep -rl 'Starter Kit' --exclude='*.md' --exclude-dir='.git' --exclude-dir='node_modules' . | xargs sed -i '' 's/Starter Kit/<your_project_name>/g'
 ```
 
-Then, follow the instructions instructions to get started.
+Then, follow the instructions to get started.
 
 ### Using GitHub Codespaces
 

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -49,7 +49,7 @@ This generates:
 - Kysely types
 - Zod schemas
 
-This auto-runs before `npm run dev`
+This auto-runs before `pnpm dev`
 
 ### 3. Run Migrations
 
@@ -132,7 +132,7 @@ const activeUsers = await db.$kysely
 Generated Zod schemas are available for runtime validation:
 
 ```typescript
-import { UserCreateSchema } from '@acme/db/generated/zod'
+import { UserCreateSchema } from '@acme/db/validators'
 
 // Validate user input
 const result = UserCreateSchema.safeParse({
@@ -180,9 +180,9 @@ const result = await db.$transaction(
   },
 )
 
-// Kysely transactions
-We are not supposed to use `db.$kysely.transaction()` directly as it is not supported by the extension. Instead, use Prisma transactions as shown above.
 ```
+
+> **Note:** Do not use `db.$kysely.transaction()` directly — it is not supported by the Prisma-Kysely extension. Use Prisma transactions as shown above instead.
 
 ### Raw SQL Queries
 
@@ -198,9 +198,9 @@ const users = await db.$queryRaw`
 await db.$executeRaw`
   UPDATE "User" SET name = ${newName} WHERE id = ${userId}
 `
-
-Prisma\'s `queryRaw` and `executeRaw` template strings automatically escapes to prevent SQL injection. To leverage on this feature, **DO NOT** build your queries up piece meal but pass the full query in here, with string parameters (`${your_parameter}`) as needed
 ```
+
+> **Note:** Prisma's `$queryRaw` and `$executeRaw` template strings automatically escape parameters to prevent SQL injection. Pass the full query as a single template literal with `${parameters}` inline — do **not** build queries piecemeal.
 
 ## Available Scripts
 
@@ -244,12 +244,13 @@ pnpm format
 ### Default Export (`@acme/db`)
 
 ```typescript
-import { db, Prisma, PrismaClient } from '@acme/db'
+import { db } from '@acme/db'
+import type { Prisma, PrismaClient } from '@acme/db'
 ```
 
 - `db` - Main database client (Prisma with Kysely extension)
-- `Prisma` - Prisma namespace for types
-- `PrismaClient` - Raw Prisma client type
+- `Prisma` - Prisma namespace for types (type-only export)
+- `PrismaClient` - Raw Prisma client type (type-only export)
 
 ### Client Export (`@acme/db/client`)
 
@@ -258,6 +259,14 @@ import { PrismaClient } from '@acme/db/client'
 ```
 
 Raw PrismaClient exports, mainly for testing purposes.
+
+### Extensions Export (`@acme/db/extensions`)
+
+```typescript
+import { kyselyPrismaExtension } from '@acme/db/extensions'
+```
+
+The Kysely Prisma extension — useful when you need to extend a test client with Kysely capabilities.
 
 ### Browser Export (`@acme/db/browser`)
 
@@ -274,6 +283,22 @@ import { QueryMode, SortOrder } from '@acme/db/enums'
 ```
 
 Prisma-generated enums for use in queries.
+
+### Validators Export (`@acme/db/validators`)
+
+```typescript
+import { UserCreateSchema } from '@acme/db/validators'
+```
+
+Auto-generated Zod schemas for all Prisma models.
+
+### Kysely Export (`@acme/db/kysely`)
+
+```typescript
+import type { DB } from '@acme/db/kysely'
+```
+
+Kysely database type definitions generated from the Prisma schema.
 
 ## Development Workflow
 
@@ -336,6 +361,7 @@ const result = await db.$kysely
 
 ## Best Practices
 
+1. **Use Prisma for Standard CRUD** - Prefer Prisma's fluent API for straightforward queries
 2. **Leverage Kysely for Complex Queries** - Use Kysely for queries that are difficult to express with Prisma
 3. **Use Generated Zod Schemas** - Validate external input before passing to database
 4. **Index Frequently Queried Fields** - Add indexes in your schema for better performance

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -177,9 +177,8 @@ const result = await db.$transaction(
   {
     maxWait: 5000, // 5 seconds
     timeout: 10000, // 10 seconds
-  },
+  }
 )
-
 ```
 
 > **Note:** Do not use `db.$kysely.transaction()` directly — it is not supported by the Prisma-Kysely extension. Use Prisma transactions as shown above instead.


### PR DESCRIPTION
## Summary

- Updates Next.js version from v15 to v16 and adds missing packages (`common`, `logging`, `redis`, `validators`) and tooling dirs (`github`, `storybook`) to the project structure in the root README
- Fixes several inaccuracies in `packages/db/README.md`: corrects the Zod schema import path (`@acme/db/validators`), marks `Prisma`/`PrismaClient` as type-only exports, adds missing package exports (`extensions`, `validators`, `kysely`), and moves inline code-block notes into proper blockquotes
- Fixes minor issues: typo ("instructions instructions"), `npm run dev` → `pnpm dev`, and missing Best Practices item 1

## Test plan

- [ ] Review rendered README on GitHub for correct formatting and accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)