### PR TITLE
Update dev:next script to use @acme/web

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "db:push": "turbo -F @acme/db push",
     "db:studio": "turbo -F @acme/db studio",
     "dev": "turbo watch dev --continue",
-    "dev:next": "turbo watch dev -F @acme/nextjs...",
+    "dev:next": "turbo watch dev -F @acme/web...",
     "format": "turbo run format --continue -- --check",
     "format:fix": "turbo run format --continue -- --write",
     "lint": "turbo run lint --continue",


### PR DESCRIPTION
## Problem

The root dev:next script filters on a package that doesn't exist. The Next.js app is named @acme/web, but the script runs turbo watch dev -F @acme/nextjs.... Since no package is named @acme/nextjs, the filter matches nothing and pnpm dev:next starts no dev servers.

## Solution

_How did you solve the problem?_

**Bug Fixes**:
- Corrected the dev:next Turbo filter in the root package.json from @acme/nextjs... to @acme/web..., so it targets the actual Next.js app and its workspace dependencies.

## Before & After Screenshots

n/a

## Tests

- run `pnpm dev:next`
## Deploy Notes

local dev-script fix
**New environment variables**:

n/a
**New scripts**:

n/a
**New dependencies**:

n/a
**New dev dependencies**:

n/a
