### PR TITLE
chore: adopt starter-kitty-logging v0.2.0 session audit API

### DIFF
--- a/apps/web/src/server/api/routers/auth/auth.email.router.ts
+++ b/apps/web/src/server/api/routers/auth/auth.email.router.ts
@@ -2,7 +2,6 @@ import z from 'zod'
 
 import { createTRPCRouter, publicProcedure } from '../../trpc'
 
-import { createLogger } from '~/lib/logger'
 import { emailLogin, emailVerifyOtp } from '~/server/modules/auth/auth.service'
 import { loginUserByEmail } from '~/server/modules/user/user.service'
 import {
@@ -43,18 +42,10 @@ export const emailAuthRouter = createTRPCRouter({
       ctx.session.sessionId = sessionId
       await ctx.session.save()
 
-      // ctx.logger was built from the pre-login session, so it lacks the
-      // user_id / correlation_id bindings. Rebuild it with the freshly
-      // created identity so the login audit lines carry the same correlation
-      // fields as the session's subsequent requests.
-      const logger = createLogger({
-        path: 'auth.email.verifyOtp',
-        headers: ctx.headers,
-        userId: user.id,
-        sessionId,
-      })
-      logger.audit.authn.sessionCreated({ sessionId })
-      logger.audit.authn.loginSucceeded({
+      // userId is payload-borne on these events, so ctx.logger (already carrying
+      // client_ip / user_agent from headers) is sufficient; no rebuild needed.
+      ctx.logger.audit.authn.sessionCreated({ sessionId, userId: user.id })
+      ctx.logger.audit.authn.loginSucceeded({
         userId: user.id,
         username: user.email,
         sessionId,

--- a/apps/web/src/server/api/routers/auth/auth.router.ts
+++ b/apps/web/src/server/api/routers/auth/auth.router.ts
@@ -4,10 +4,14 @@ import { emailAuthRouter } from './auth.email.router'
 export const authRouter = createTRPCRouter({
   email: emailAuthRouter,
   logout: publicProcedure.mutation(({ ctx }) => {
-    const { sessionId } = ctx.session
+    const { sessionId, userId } = ctx.session
     ctx.session.destroy()
-    if (sessionId) {
-      ctx.logger.audit.authn.sessionTerminated({ sessionId, reason: 'logout' })
+    if (sessionId && userId) {
+      ctx.logger.audit.authn.sessionTerminated({
+        sessionId,
+        userId,
+        reason: 'logout',
+      })
     }
     return
   }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^5.2.2
       version: 5.2.2
     '@opengovsg/starter-kitty-logging':
-      specifier: ^0.1.1
-      version: 0.1.1
+      specifier: ^0.2.0
+      version: 0.2.0
     '@types/node':
       specifier: ^24.10.4
       version: 24.10.4
@@ -491,7 +491,7 @@ importers:
     dependencies:
       '@opengovsg/starter-kitty-logging':
         specifier: 'catalog:'
-        version: 0.1.1
+        version: 0.2.0
       '@t3-oss/env-core':
         specifier: catalog:t3-env
         version: 0.13.8(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
@@ -1653,8 +1653,8 @@ packages:
       react: '>= 18'
       react-aria-components: ^1.14.0
 
-  '@opengovsg/starter-kitty-logging@0.1.1':
-    resolution: {integrity: sha512-STW97OsOnQEKHW4MchrycEMe7+Pg6gXlrxKYoZNEAjnt57MRZBKoDeqEKi/HgoOAGK35nybe3LTlPJIaydaG/A==}
+  '@opengovsg/starter-kitty-logging@0.2.0':
+    resolution: {integrity: sha512-tnDWAIQFy6ARwaqohqwAMXg1XUlw8t+Dk7ToNWhcQa5ckzFS6SCN4xiUnZZ2ttxNrIdZFEt+11b+fNZAOacC+A==}
 
   '@opentelemetry/api-logs@0.208.0':
     resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
@@ -7725,7 +7725,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@opengovsg/starter-kitty-logging@0.1.1':
+  '@opengovsg/starter-kitty-logging@0.2.0':
     dependencies:
       pino: 10.1.0
       pino-pretty: 13.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 
 catalog:
   '@hookform/resolvers': ^5.2.2
-  '@opengovsg/starter-kitty-logging': ^0.1.1
+  '@opengovsg/starter-kitty-logging': ^0.2.0
   '@types/node': ^24.10.4
   'oxlint': ^1.64.0
   'oxlint-tsgolint': ^0.22.1


### PR DESCRIPTION
## What

Bump `@opengovsg/starter-kitty-logging` to `^0.2.0` and adopt the new session audit API where `sessionCreated` / `sessionTerminated` take `userId` as a required payload field (promoted to `user_id`) instead of requiring `user_id` in request scope.

- **`auth.email.router.ts`** (`verifyOtp`): dropped the `createLogger` rebuild that existed solely to bind `user_id` for `sessionCreated`. `ctx.logger` already carries `client_ip` / `user_agent` from headers, so `sessionCreated` and `loginSucceeded` now run on it directly with `userId` passed inline.
- **`auth.router.ts`** (`logout`): pass the session `userId` to `sessionTerminated` (now required).

## Why

Upstream [opengovsg/starter-kitty#74](https://github.com/opengovsg/starter-kitty/pull/74) made `userId` payload-borne on these session events (`sessionCreated` is the call that binds identity; termination may run outside a request). This removes the chicken-and-egg workaround of minting a fresh logger just to satisfy the old `user_id` scope requirement.

## Note

The old rebuild also bound `correlation_id = sessionId` as a side effect on the two login lines. Those events already carry `session_id` via `contextFields`, so session grouping is intact; only the `correlation_id` facet is dropped from those specific lines.

## Checks

- `pnpm typecheck` clean (no auth/logger errors)
- 51 server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)