### PR TITLE
ci: add turborepo remote caching with actions/cache

### DIFF
--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -10,5 +10,13 @@ runs:
         node-version-file: '.nvmrc'
         cache: 'pnpm'
 
+    - name: Cache turbo build setup
+      uses: actions/cache@v6
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+
     - shell: bash
       run: pnpm install


### PR DESCRIPTION
Adds Turborepo remote caching via `actions/cache`, following the [official GitHub Actions guidance](https://turborepo.dev/docs/guides/ci-vendors/github-actions#remote-caching-with-github-actionscache).

The cache step lives in the shared `tooling/github/setup` composite action, so all CI jobs (lint, format, typecheck, test) share the `.turbo` cache without duplicating the step.

- Uses `actions/cache@v6`
- Key/restore-keys match the docs exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)