### PR TITLE
ci: scope turbo cache key per job to avoid reserve conflicts

### DIFF
--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -14,9 +14,9 @@ runs:
       uses: actions/cache@v6
       with:
         path: .turbo
-        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-turbo-
+          ${{ runner.os }}-turbo-${{ github.job }}-
 
     - shell: bash
       run: pnpm install


### PR DESCRIPTION
## Problem

CI jobs were logging `Failed to save: Unable to reserve cache with key Linux-turbo-<sha>, another job may be creating this cache.` during the post-setup step.

The turbo remote-caching setup (added in #637) followed the [Turborepo GitHub Actions guide](https://turborepo.dev/docs/guides/ci-vendors/github-actions#remote-caching-with-github-actionscache) literally, but that example assumes a single job. Here the `actions/cache` step lives in the shared `tooling/github/setup` composite action, which all four jobs (`lint`, `format`, `typecheck`, `test`) run in parallel with the **same** key `${{ runner.os }}-turbo-${{ github.sha }}`. GitHub's cache reservation is exclusive per key, so the first job to finish reserves it and the other three fail.

## Fix

Scope the cache key per job by including `${{ github.job }}` (available inside composite actions). Each job now reserves and restores its own cache lane, with `restore-keys` falling back to that job's previous runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)