### PR TITLE
ci: scope turbo cache key by matrix job index

### DIFF
--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -14,9 +14,10 @@ runs:
       uses: actions/cache@v6
       with:
         path: .turbo
-        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+        # strategy.job-index prevents matrix jobs (e.g. concurrent vitest shards) sharing the same job name from clashing over one cache entry
+        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-turbo-${{ github.job }}-
+          ${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-
 
     - shell: bash
       run: pnpm install


### PR DESCRIPTION
## Summary
- Adds `strategy.job-index` to the turbo cache key and restore-keys in `tooling/github/setup/action.yml`
- Prevents matrix jobs sharing the same `github.job` name (e.g. concurrent vitest shards) from clashing over a single turbo cache entry

## Test plan
- [ ] Verify CI runs successfully and turbo cache is restored/saved per matrix job without conflicts