### PR TITLE
ci: run e2e suite against Vercel preview deployments

### DIFF
--- a/.github/workflows/e2e-preview.yml
+++ b/.github/workflows/e2e-preview.yml
@@ -1,0 +1,179 @@
+name: E2E against Vercel preview
+
+on:
+  # Fired automatically by Vercel's GitHub integration whenever a deployment
+  # changes state - no extra setup needed beyond connecting the repo to Vercel.
+  deployment_status:
+  workflow_dispatch:
+    inputs:
+      preview-url:
+        description: 'Vercel preview URL to test against (e.g. https://my-app-foo.vercel.app)'
+        required: true
+        type: string
+      sha:
+        description: 'Commit SHA to check out (defaults to the workflow ref HEAD)'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.deployment.sha || github.event.inputs.sha || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  statuses: write
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  # Branch isn't needed to run the suite, but Datadog Test Optimization needs
+  # DD_GIT_BRANCH for PR attribution: deployment_status checks out a detached
+  # HEAD, so dd-trace can't infer the branch from git.
+  resolve-branch:
+    # Run for workflow_dispatch unconditionally. For deployment_status, only
+    # successful preview deployments - Vercel names the deployment environment
+    # 'Preview' (or 'Preview - <project>' on multi-project repos).
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.deployment_status.state == 'success' &&
+       startsWith(github.event.deployment.environment, 'Preview'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      branch: ${{ steps.resolve.outputs.branch }}
+    steps:
+      - name: Resolve PR branch from commit SHA
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.deployment.sha || github.event.inputs.sha || github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          branch=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+            --jq '.[0].head.ref // ""' 2>/dev/null || echo "")
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          if [ -n "$branch" ]; then
+            echo "Resolved branch: $branch"
+          else
+            echo "No PR branch found for $HEAD_SHA"
+          fi
+
+  e2e:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.deployment_status.state == 'success' &&
+       startsWith(github.event.deployment.environment, 'Preview'))
+    needs: resolve-branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.deployment.sha || github.event.inputs.sha || github.sha }}
+
+      - name: Setup
+        uses: ./tooling/github/setup
+
+      # The workflow run itself doesn't show up as a required PR check for
+      # deployment_status events, so publish an explicit commit status that
+      # branch protection can require.
+      - name: Mark commit status pending
+        uses: actions/github-script@v8
+        env:
+          HEAD_SHA: ${{ github.event.deployment.sha || github.event.inputs.sha || github.sha }}
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_SHA,
+              state: 'pending',
+              context: 'E2E against Vercel preview',
+              description: 'Running Playwright suite…',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            })
+
+      - name: Cache & install Playwright
+        uses: ./tooling/github/playwright-cache
+        with:
+          filter: '@acme/web'
+
+      # Skipped fixture-based tests are still *loaded* by the runner and
+      # import the Prisma client, so it must exist.
+      - name: Generate Prisma client
+        run: cp .env.example .env && pnpm --filter @acme/db generate
+
+      - name: Configure Datadog Test Optimization
+        env:
+          DD_SERVICE_NAME: ${{ secrets.DD_SERVICE_NAME }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        if: env.DD_SERVICE_NAME != '' && env.DD_API_KEY != ''
+        # datadog/test-visibility-github-action@v2.10.0, using commit hash to pin to silence codeQL
+        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b
+        with:
+          languages: js
+          service: ${{ secrets.DD_SERVICE_NAME }}
+          api_key: ${{ secrets.DD_API_KEY }}
+          # Keep in sync with the dd-trace version in pnpm-workspace.yaml catalog
+          js-tracer-version: 6.1.0
+
+      - name: Run E2E suite against preview
+        id: e2e
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment_url || github.event.inputs.preview-url }}
+          # Bypass Vercel deployment protection if the preview is gated.
+          # Configured in Vercel: Settings -> Deployment Protection ->
+          # Protection Bypass for Automation. Empty is fine when the project
+          # has no deployment protection.
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          # Preload dd-trace so Playwright reports to Datadog Test
+          # Optimization. Playwright takes only `-r` (DD_TRACE_PACKAGE); the
+          # `--import` ESM loader is Vitest-only. Empty when Datadog is not
+          # configured.
+          NODE_OPTIONS: ${{ secrets.DD_API_KEY && secrets.DD_SERVICE_NAME && format('-r {0}', env.DD_TRACE_PACKAGE) || '' }}
+          # Match the vitest runs' `ci` env so unit + e2e group together.
+          DD_ENV: ci
+          # deployment_status checks out a detached HEAD, so pin git metadata
+          # explicitly for correct PR attribution / flaky-test grouping.
+          DD_GIT_COMMIT_SHA: ${{ github.event.deployment.sha || github.event.inputs.sha || github.sha }}
+          DD_GIT_BRANCH: ${{ needs.resolve-branch.outputs.branch }}
+        run: pnpm --filter @acme/web e2e
+
+      - name: Upload Playwright report
+        if: '!cancelled()'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.event.deployment.sha || github.event.inputs.sha || github.sha }}
+          # HTML report (always present on CI) + raw outputDir (traces /
+          # screenshots / videos, only populated on retries or failures).
+          path: |
+            apps/web/playwright-report
+            apps/web/tests/e2e/test-results
+          retention-days: 7
+
+      - name: Update commit status with result
+        if: always()
+        uses: actions/github-script@v8
+        env:
+          HEAD_SHA: ${{ github.event.deployment.sha || github.event.inputs.sha || github.sha }}
+          E2E_OUTCOME: ${{ steps.e2e.outcome }}
+        with:
+          script: |
+            const state =
+              process.env.E2E_OUTCOME === 'success' ? 'success' : 'failure'
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_SHA,
+              state,
+              context: 'E2E against Vercel preview',
+              description:
+                state === 'success'
+                  ? 'Playwright suite passed'
+                  : 'Playwright suite failed',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            })

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,9 +6,26 @@ import dotenv from 'dotenv'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-dotenv.config({ path: path.resolve(__dirname, '.env.e2e'), quiet: true })
+// The Playwright runner may import test files that transitively pull in
+// `~/env` (t3-env). The runner itself only needs a couple of vars - the
+// *server* it talks to validates its own env - so skip the t3-env validation
+// here, decoupling the suite from the full server env schema.
+process.env.SKIP_ENV_VALIDATION = '1'
 
-const baseUrl = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3111'
+// Mode selection. `PLAYWRIGHT_TEST_BASE_URL` set (CI against a deployed
+// Vercel preview, or a loop pointed at any deployed URL) => preview mode: no
+// local stack, hit that URL. Otherwise local mode: boot the app here.
+const externalBaseUrl = process.env.PLAYWRIGHT_TEST_BASE_URL
+const isLocal = !externalBaseUrl
+
+// Local mode: load this suite's own E2E env (consumed by the dev-e2e server
+// Playwright spawns). Preview mode runs against a deployed app whose env is
+// managed by Vercel, so nothing to load.
+if (isLocal) {
+  dotenv.config({ path: path.resolve(__dirname, '.env.e2e'), quiet: true })
+}
+
+const baseUrl = externalBaseUrl ?? 'http://localhost:3111'
 console.log(`ℹ️ Using base URL "${baseUrl}"`)
 
 const opts = {
@@ -17,22 +34,43 @@ const opts = {
   // collectCoverage: !!process.env.PLAYWRIGHT_HEADLESS,
 }
 
+// Vercel deployment-protection bypass (preview mode only). If the preview is
+// gated, every request is blocked at Vercel's edge before reaching the app;
+// attaching this header bypasses that. Configured in Vercel: Settings ->
+// Deployment Protection -> Protection Bypass for Automation.
+const vercelBypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+const extraHTTPHeaders =
+  !isLocal && vercelBypass
+    ? { 'x-vercel-protection-bypass': vercelBypass }
+    : undefined
+
 export default defineConfig({
-  webServer: {
-    command: 'pnpm dev-e2e',
-    url: baseUrl,
-    reuseExistingServer: !process.env.CI, // Reuses the server locally, but starts a new one in CI
-  },
+  // Local mode boots the app via `dev-e2e` (Next dev on a fixed port, env
+  // from `.env.e2e`). Preview mode hits a deployed URL and runs no server.
+  ...(isLocal
+    ? {
+        webServer: {
+          command: 'pnpm dev-e2e',
+          url: baseUrl,
+          reuseExistingServer: !process.env.CI, // Reuses the server locally, but starts a new one in CI
+        },
+      }
+    : {}),
   use: {
     baseURL: baseUrl,
     trace: 'on-first-retry',
+    extraHTTPHeaders,
   },
   testDir: './tests/e2e',
   fullyParallel: false,
   outputDir: './tests/e2e/test-results',
-  // 'github' for GitHub Actions CI to generate annotations, plus a concise 'dot'
-  // default 'list' when running locally
-  reporter: process.env.CI ? 'github' : 'list',
+  // On CI, pair 'github' (PR annotations on failures) with 'list' so the log
+  // shows each test name as it runs, and write the HTML report so the
+  // workflow can upload it as an artifact (otherwise outputDir is empty on a
+  // passing run and there's nothing to attach). Plain 'list' locally.
+  reporter: process.env.CI
+    ? [['github'], ['list'], ['html', { open: 'never' }]]
+    : 'list',
   projects: [
     {
       name: 'chromium',
@@ -40,6 +78,7 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
         baseURL: baseUrl,
         headless: opts.headless,
+        extraHTTPHeaders,
       },
     },
   ],

--- a/apps/web/src/app/_components/errors/error-card.tsx
+++ b/apps/web/src/app/_components/errors/error-card.tsx
@@ -1,14 +1,8 @@
-import dynamic from 'next/dynamic'
-
 import { cn } from '@opengovsg/oui-theme'
 
-import { ErrorSvg } from '@acme/ui/svgs'
+import { GoBackButton } from './go-back-button'
 
-const GoBackButton = dynamic(
-  () =>
-    import('./go-back-button').then((mod) => ({ default: mod.GoBackButton })),
-  { ssr: false }
-)
+import { ErrorSvg } from '@acme/ui/svgs'
 
 interface ErrorCardProps {
   fullscreen?: boolean

--- a/apps/web/src/app/_components/errors/go-back-button.tsx
+++ b/apps/web/src/app/_components/errors/go-back-button.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+
 import { useRouter } from 'next/navigation'
 
 import { Button } from '@opengovsg/oui'
@@ -7,8 +9,13 @@ import { Button } from '@opengovsg/oui'
 export const GoBackButton = () => {
   const router = useRouter()
 
-  // window.history.length is always >= 1 (current entry); > 1 means there's a previous entry
-  const canGoBack = window.history.length > 1
+  // window.history.length is always >= 1 (current entry); > 1 means there's a
+  // previous entry. Read it in an effect so the component is SSR-safe: it can
+  // then be imported directly from Server Components (error pages).
+  const [canGoBack, setCanGoBack] = useState(false)
+  useEffect(() => {
+    setCanGoBack(window.history.length > 1)
+  }, [])
 
   if (!canGoBack) return null
 

--- a/apps/web/tests/e2e/app-fixture.ts
+++ b/apps/web/tests/e2e/app-fixture.ts
@@ -10,18 +10,29 @@ import {
 } from './setup/db-setup'
 import { flushRedis as flushRedisFn, startRedis } from './setup/redis-setup'
 
+// When PLAYWRIGHT_TEST_BASE_URL is set, tests run against a deployed app
+// (typically a Vercel preview). The testcontainers stack is then irrelevant:
+// there is no local DB or Redis to manage, and the deployed server has its
+// own. Tests built on this fixture need that local control, so they skip.
+// oxlint-disable-next-line no-restricted-properties
+const isPreviewMode = Boolean(process.env.PLAYWRIGHT_TEST_BASE_URL)
+
 interface DatabaseFixture {
-  databaseContainer: Awaited<ReturnType<typeof startDatabase>>
+  databaseContainer: Awaited<ReturnType<typeof startDatabase>> | null
   resetDatabase: () => Promise<void>
 }
 
 interface RedisFixture {
-  redisContainer: Awaited<ReturnType<typeof startRedis>>
+  redisContainer: Awaited<ReturnType<typeof startRedis>> | null
   flushRedis: () => Promise<void>
 }
 
 const test = baseTest.extend<DatabaseFixture & RedisFixture>({
   databaseContainer: async ({}, use) => {
+    if (isPreviewMode) {
+      await use(null)
+      return
+    }
     const container = await startDatabase()
 
     await use(container)
@@ -29,11 +40,15 @@ const test = baseTest.extend<DatabaseFixture & RedisFixture>({
 
   resetDatabase: async ({ databaseContainer }, use) => {
     await use(async () => {
-      await resetDbToSnapshot(databaseContainer)
+      if (databaseContainer) await resetDbToSnapshot(databaseContainer)
     })
   },
 
   redisContainer: async ({}, use) => {
+    if (isPreviewMode) {
+      await use(null)
+      return
+    }
     const container = await startRedis()
 
     await use(container)
@@ -41,12 +56,21 @@ const test = baseTest.extend<DatabaseFixture & RedisFixture>({
 
   flushRedis: async ({ redisContainer }, use) => {
     await use(async () => {
-      await flushRedisFn(redisContainer)
+      if (redisContainer) await flushRedisFn(redisContainer)
     })
   },
 })
 
+// Fixture-based tests require the local stack; skip them on preview runs.
+test.beforeEach(() => {
+  test.skip(
+    isPreviewMode,
+    'Requires the local testcontainers stack; not run against deployed previews'
+  )
+})
+
 test.beforeAll(async ({ databaseContainer }) => {
+  if (!databaseContainer) return
   await applyMigrations(databaseContainer)
   // Add more seed data here as needed before taking the snapshot
   await takeDbSnapshot(databaseContainer)
@@ -54,8 +78,8 @@ test.beforeAll(async ({ databaseContainer }) => {
 
 test.afterAll(async ({ databaseContainer, redisContainer }) => {
   await Promise.all([
-    databaseContainer.container.stop(),
-    redisContainer.container.stop(),
+    databaseContainer?.container.stop(),
+    redisContainer?.container.stop(),
   ])
 })
 

--- a/apps/web/tests/e2e/smoke.test.ts
+++ b/apps/web/tests/e2e/smoke.test.ts
@@ -1,13 +1,15 @@
-import { expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
-import { test } from './app-fixture'
-
-import { env } from '~/env'
+// Deliberately not `~/env`: the smoke suite also runs against deployed Vercel
+// previews, where the runner has no server env. Falls back to the schema
+// default for NEXT_PUBLIC_APP_NAME; set the var when the app is renamed.
+// oxlint-disable-next-line no-restricted-properties
+const appName = process.env.NEXT_PUBLIC_APP_NAME ?? 'Starter Kit'
 
 test('go to /', async ({ page }) => {
   await page.goto('/')
 
-  await page.waitForSelector(`text=${env.NEXT_PUBLIC_APP_NAME}`)
+  await page.waitForSelector(`text=${appName}`)
 })
 
 test('test 404', async ({ page }) => {

--- a/tooling/github/playwright-cache/action.yml
+++ b/tooling/github/playwright-cache/action.yml
@@ -1,0 +1,52 @@
+name: 'Cache & install Playwright'
+description: 'Restore the Playwright Chromium browser from cache (or install it on a miss), keyed on the installed Playwright version.'
+inputs:
+  filter:
+    description: 'pnpm workspace filter for a package that depends on @playwright/test (e.g. @acme/web).'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Playwright pins browser binaries to its own version, so key the cache on
+    # the installed version: a Playwright bump misses the cache and reinstalls,
+    # otherwise we restore the cached binaries and skip the (slow) download.
+    - name: Resolve Playwright version
+      id: version
+      shell: bash
+      env:
+        FILTER: ${{ inputs.filter }}
+      run: |
+        set -euo pipefail
+        version=$(pnpm --filter "$FILTER" exec playwright --version | awk '{ print $2 }')
+        # Fail loudly: an empty version would write a degenerate cache key that
+        # collides across jobs and restores the wrong (or no) browser binaries.
+        if [ -z "$version" ]; then
+          echo "::error::Could not resolve a Playwright version for filter '$FILTER'"
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Playwright browsers
+      id: cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ms-playwright
+        # Browser binaries are OS- and arch-specific, so both are in the key.
+        key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ steps.version.outputs.version }}
+
+    - name: Install Playwright browsers
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        FILTER: ${{ inputs.filter }}
+      run: pnpm --filter "$FILTER" exec playwright install --with-deps chromium
+
+    # On a cache hit the browser binaries are restored, but OS-level shared
+    # libraries aren't cached - install just those so a cached browser can run.
+    - name: Install Playwright OS dependencies
+      if: steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      env:
+        FILTER: ${{ inputs.filter }}
+      run: pnpm --filter "$FILTER" exec playwright install-deps chromium


### PR DESCRIPTION
## Summary

Adds an e2e workflow that runs the Playwright smoke suite against every successful Vercel preview deployment, modeled on [confetti's e2e-preview.yml](https://github.com/opengovsg/confetti/blob/main/.github/workflows/e2e-preview.yml) but adapted for a generic starter kit.

### Workflow (`.github/workflows/e2e-preview.yml`)
- Triggers on `deployment_status` - fired automatically by Vercel's GitHub integration, so it works out of the box for any repo connected to Vercel (no webhook bridge needed, unlike confetti's `repository_dispatch`). Filtered to successful `Preview` deployments. Also supports manual `workflow_dispatch` with a preview URL.
- **No secrets required to run.** Degrades gracefully instead of gating the whole workflow:
  - Datadog Test Optimization step skips itself when `DD_API_KEY` / `DD_SERVICE_NAME` are absent (same pattern as `ci.yml`)
  - `VERCEL_AUTOMATION_BYPASS_SECRET` is passed through; empty is fine for unprotected previews, and gated previews work once the secret is set
- Posts an explicit `E2E against Vercel preview` commit status (pending → success/failure) that branch protection can require, since `deployment_status` runs don't surface reliably as PR checks.
- Uploads the Playwright HTML report + traces as an artifact; `resolve-branch` job pins `DD_GIT_BRANCH` for Datadog PR attribution on detached-HEAD checkouts.

### Playwright dual-mode
- `playwright.config.ts`: when `PLAYWRIGHT_TEST_BASE_URL` is set (preview mode), skip the local `webServer`, attach the `x-vercel-protection-bypass` header, and skip t3-env validation for the runner. Local mode is unchanged.
- `smoke.test.ts`: drops the incidental container-fixture and `~/env` imports so it runs against deployed previews.
- `app-fixture.ts`: fixture-based tests (testcontainers Postgres/Redis) self-skip in preview mode - they need local stack control, so the preview run is a deployment-verification gate, not a full functional suite.
- Ports confetti's `tooling/github/playwright-cache` composite action (Chromium cache keyed on Playwright version).

### Drive-by fix
Local e2e was broken on main: `error-card.tsx` used `dynamic(..., { ssr: false })` from a Server Component, which Next.js rejects, so the dev server never compiled. `GoBackButton` now reads `window.history` in an effect (SSR-safe) and is imported statically.

## Test plan
- [x] Local e2e suite passes end-to-end (`pnpm e2e`: 2 passed, boots dev server + testcontainers)
- [x] Preview mode verified without docker: `playwright test --list` loads, and a fixture-based test correctly reports `skipped`
- [x] Lint, format, typecheck clean
- [ ] First real preview run happens once this merges (or trigger via `workflow_dispatch` against any preview URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)