### PR TITLE
chore(logging): upgrade starter-kitty-logging to 0.4.0

### DIFF
--- a/apps/web/src/server/api/routers/auth/auth.email.router.ts
+++ b/apps/web/src/server/api/routers/auth/auth.email.router.ts
@@ -36,7 +36,7 @@ export const emailAuthRouter = createTRPCRouter({
     .input(emailVerifyOtpSchema)
     .mutation(async ({ input: { email, token, codeVerifier }, ctx }) => {
       await emailVerifyOtp({ email, token, codeVerifier, logger: ctx.logger })
-      const user = await loginUserByEmail(email)
+      const user = await loginUserByEmail(email, ctx.logger)
       const sessionId = crypto.randomUUID()
       ctx.session.userId = user.id
       ctx.session.sessionId = sessionId

--- a/apps/web/src/server/modules/user/__tests__/user.service.spec.ts
+++ b/apps/web/src/server/modules/user/__tests__/user.service.spec.ts
@@ -1,10 +1,23 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { resetTables } from '~tests/db/utils'
+
+import type { Logger } from '@acme/logging'
 
 import { db } from '@acme/db'
 
 import { AccountProvider } from '../../auth/auth.constants'
 import { getUserById, loginUserByEmail } from '../user.service'
+
+// Minimal Logger stub capturing the self-signup audit call.
+const makeAuditLoggerStub = () => {
+  const accountCreated = vi.fn<(input: { targetUserId: string }) => void>()
+  const logger = {
+    withBindings: () => ({
+      audit: { userManagement: { accountCreated } },
+    }),
+  } as unknown as Logger
+  return { logger, accountCreated }
+}
 
 describe('user.service', () => {
   beforeEach(async () => {
@@ -37,6 +50,19 @@ describe('user.service', () => {
       })
       expect(account).toBeDefined()
       expect(account?.providerAccountId).toBe(email)
+    })
+
+    it('should emit accountCreated audit only for a first-time (new) user', async () => {
+      const email = 'signup@example.com'
+      const { logger, accountCreated } = makeAuditLoggerStub()
+
+      const user = await loginUserByEmail(email, logger)
+      expect(accountCreated).toHaveBeenCalledTimes(1)
+      expect(accountCreated).toHaveBeenCalledWith({ targetUserId: user.id })
+
+      // A returning login must not re-emit the signup event.
+      await loginUserByEmail(email, logger)
+      expect(accountCreated).toHaveBeenCalledTimes(1)
     })
 
     it('should parse and store the name from email address', async () => {

--- a/apps/web/src/server/modules/user/user.service.ts
+++ b/apps/web/src/server/modules/user/user.service.ts
@@ -1,17 +1,24 @@
 import { parseOneAddress } from 'email-addresses'
 
+import type { Logger } from '@acme/logging'
+
 import { db } from '@acme/db'
 
 import { AccountProvider } from '../auth/auth.constants'
 import { defaultUserSelect } from './user.select'
 
-export const loginUserByEmail = async (email: string) => {
+export const loginUserByEmail = async (email: string, logger?: Logger) => {
   const parsedEmail = parseOneAddress(email)
   if (!parsedEmail || parsedEmail.type === 'group') {
     throw new Error('Invalid email address')
   }
 
-  return await db.$transaction(async (tx) => {
+  const { user, isNewUser } = await db.$transaction(async (tx) => {
+    const existing = await tx.user.findUnique({
+      where: { email },
+      select: { id: true },
+    })
+
     const user = await tx.user.upsert({
       where: { email },
       update: {
@@ -39,8 +46,23 @@ export const loginUserByEmail = async (email: string) => {
         userId: user.id,
       },
     })
-    return user
+    // isNewUser is read at READ COMMITTED, so two concurrent first-ever logins
+    // for the same email can both see "no user" and each emit accountCreated
+    // once. Unreachable in the OTP flow (needs two valid OTPs submitted in the
+    // same instant) and a duplicate audit line dedupes at the sink. If a flow
+    // makes this reachable, take a pg advisory lock or use SERIALIZABLE + retry.
+    return { user, isNewUser: !existing }
   })
+
+  // A first email login is a self-signup: the acting user is the account just
+  // created, so bind user_id before emitting to attribute the actor (== target).
+  if (isNewUser) {
+    logger
+      ?.withBindings({ userId: user.id })
+      .audit.userManagement.accountCreated({ targetUserId: user.id })
+  }
+
+  return user
 }
 
 export const getUserById = async (userId: string) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^5.2.2
       version: 5.2.2
     '@opengovsg/starter-kitty-logging':
-      specifier: ^0.2.0
-      version: 0.2.0
+      specifier: ^0.4.0
+      version: 0.4.0
     '@types/node':
       specifier: ^24.10.4
       version: 24.10.4
@@ -485,7 +485,7 @@ importers:
     dependencies:
       '@opengovsg/starter-kitty-logging':
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 0.4.0
       '@t3-oss/env-core':
         specifier: catalog:t3-env
         version: 0.13.8(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
@@ -1669,8 +1669,8 @@ packages:
       react: '>= 18'
       react-aria-components: ^1.14.0
 
-  '@opengovsg/starter-kitty-logging@0.2.0':
-    resolution: {integrity: sha512-tnDWAIQFy6ARwaqohqwAMXg1XUlw8t+Dk7ToNWhcQa5ckzFS6SCN4xiUnZZ2ttxNrIdZFEt+11b+fNZAOacC+A==}
+  '@opengovsg/starter-kitty-logging@0.4.0':
+    resolution: {integrity: sha512-/FH+vLV78LNgpdxfU3Jxb15cj3ZeNM2K6wfchprkMqEPJBqCmYTMjcE7fUfewY1z96UcwcTLQ8ak1KifD5cGEg==}
 
   '@opentelemetry/api-logs@0.208.0':
     resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
@@ -7575,7 +7575,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@opengovsg/starter-kitty-logging@0.2.0':
+  '@opengovsg/starter-kitty-logging@0.4.0':
     dependencies:
       pino: 10.1.0
       pino-pretty: 13.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 
 catalog:
   '@hookform/resolvers': ^5.2.2
-  '@opengovsg/starter-kitty-logging': ^0.2.0
+  '@opengovsg/starter-kitty-logging': ^0.4.0
   '@types/node': ^24.10.4
   'oxlint': ^1.64.0
   'oxlint-tsgolint': ^0.22.1


### PR DESCRIPTION
## What

Upgrade `@opengovsg/starter-kitty-logging` `^0.2.0` -> `^0.4.0` and wire the one audit event this change makes worth adding.

## Changes

- **Version bump** (`pnpm-workspace.yaml`): catalog pin `^0.2.0` -> `^0.4.0`. No breaking-change fallout - the only breaking change in 0.4.0 is in the `apiUsage` group, which this app does not use.
- **`accountCreated` on self-signup** (`user.service.ts`): a first-time email login creates a user account via the upsert `create` branch but emitted no audit event. It now detects the new-user branch with a `findUnique` inside the existing transaction (the `User` model has no timestamps to distinguish create vs update) and emits `audit.userManagement.accountCreated`, using the 0.3.0 `withBindings({ userId })` to attribute the actor (actor == target for self-signup).
- Router threads `ctx.logger` in; `loginUserByEmail`'s return type is unchanged, so no churn across existing call sites.

## Not done

`apiUsage.*` wiring - no bearer-token/machine-auth flows exist in the app. Add when they do.

## Testing

- `@acme/web` and `@acme/logging` typecheck pass
- 53 tests pass (+1: `accountCreated` fires once for a new user, not on a returning login)
- lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)