### PR TITLE
chore: pin GitHub Actions to commit hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: monthly
+
   - package-ecosystem: npm
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
+    groups:
+      codeql-action:
+        applies-to: version-updates
+        patterns:
+          - 'github/codeql-action/init'
+          - 'github/codeql-action/analyze'
 
   - package-ecosystem: npm
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: monthly
+      interval: weekly
+    cooldown:
+      default-days: 7 # to make supply chain attacks harder
+    open-pull-requests-limit: 2
     groups:
       codeql-action:
         applies-to: version-updates

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -21,9 +21,9 @@ jobs:
     outputs:
       web: ${{ steps.filter.outputs.web }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
@@ -37,7 +37,7 @@ jobs:
     env:
       CHROMATIC_WEB_PROJECT_TOKEN: ${{ secrets.CHROMATIC_WEB_PROJECT_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.CHROMATIC_WEB_PROJECT_TOKEN != ''
         with:
           fetch-depth: 0 # Required for v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./tooling/github/setup
@@ -38,7 +38,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./tooling/github/setup
@@ -49,7 +49,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./tooling/github/setup
@@ -64,7 +64,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./tooling/github/setup

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,11 +32,11 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{matrix.language}}
           build-mode: ${{matrix.build-mode}}
@@ -45,6 +45,6 @@ jobs:
           config-file: opengovsg/codeql-config/codeql-config.yml@prod
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: '/language:${{matrix.language}}'

--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -4,14 +4,14 @@ description: 'Common setup steps for Actions'
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v6
-    - uses: actions/setup-node@v7
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: 'package.json'
         cache: 'pnpm'
 
     - name: Cache turbo build setup
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo
         # strategy.job-index prevents matrix jobs (e.g. concurrent vitest shards) sharing the same job name from clashing over one cache entry


### PR DESCRIPTION
## Summary
- Pin all third-party GitHub Actions (`actions/checkout`, `actions/setup-node`, `actions/cache`, `pnpm/action-setup`, `github/codeql-action/*`, `dorny/paths-filter`) to immutable commit hashes instead of mutable version tags, to harden against supply-chain attacks (tag mutation/takeover)
- Add a `github-actions` dependabot entry (weekly, 7-day cooldown, capped at 2 open PRs) to keep the pinned hashes up to date, grouping `codeql-action/init` and `codeql-action/analyze` so they bump together

## Test plan
- [ ] Confirm CI, CodeQL, and Chromatic workflows still run successfully on this branch
- [ ] Confirm dependabot config is valid (parses without errors in the Insights > Dependency graph > Dependabot tab after merge)