### PR TITLE
Update starter-kitty-* packages to their renamed packages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,5 +43,8 @@
   ],
   "[prisma]": {
     "editor.defaultFormatter": "Prisma.prisma"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -61,7 +61,7 @@
     "@acme/storybook-config": "workspace:*",
     "@acme/tailwind-config": "workspace:*",
     "@acme/tsconfig": "workspace:*",
-    "@opengovsg/starter-kitty-testcontainers": "^0.1.0",
+    "@opengovsg/testcontainers": "^0.2.0",
     "@playwright/test": "catalog:playwright",
     "@storybook/addon-a11y": "catalog:storybook10",
     "@storybook/addon-docs": "catalog:storybook10",

--- a/apps/web/src/lib/logger.ts
+++ b/apps/web/src/lib/logger.ts
@@ -23,7 +23,6 @@ export const createLogger = ({
     // We need to manually inject the trace ID from the frontend otherwise logs
     // and traces will not be correlated to the RUM session.
     source: headers.get('x-trpc-source') ?? 'unknown',
-    traceId: headers.get('x-datadog-trace-id'),
     clientIp: headers.get('cf-connecting-ip'),
     userAgent: headers.get('user-agent'),
     serverVersion: env.NEXT_PUBLIC_APP_VERSION,

--- a/apps/web/src/lib/logger.ts
+++ b/apps/web/src/lib/logger.ts
@@ -20,8 +20,6 @@ export const createLogger = ({
     // Iron-session id, bound as correlation_id so every line of a session's
     // activity can be grouped back to the session that produced it.
     correlationId: sessionId,
-    // We need to manually inject the trace ID from the frontend otherwise logs
-    // and traces will not be correlated to the RUM session.
     source: headers.get('x-trpc-source') ?? 'unknown',
     clientIp: headers.get('cf-connecting-ip'),
     userAgent: headers.get('user-agent'),

--- a/apps/web/tests/db/setup.ts
+++ b/apps/web/tests/db/setup.ts
@@ -18,17 +18,17 @@ import { readdirSync, readFileSync, statSync } from 'fs'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
 
-import {
-  getContainer,
-  getPostgresConnectionString,
-} from '@opengovsg/testcontainers'
+import { getPostgresConnectionString } from '@opengovsg/testcontainers'
 import { PrismaPg } from '@prisma/adapter-pg'
-import { vi } from 'vitest'
+import { inject, vi } from 'vitest'
 
 import { PrismaClient } from '@acme/db/client'
 import { kyselyPrismaExtension } from '@acme/db/extensions'
 
-const container = getContainer('postgres')
+const { postgres: container } = inject('testcontainers')
+if (!container) {
+  throw new Error('postgres container not provided by global-setup.ts')
+}
 
 const originalConnectionString = getPostgresConnectionString(container)
 

--- a/apps/web/tests/db/setup.ts
+++ b/apps/web/tests/db/setup.ts
@@ -21,7 +21,7 @@ import { fileURLToPath } from 'url'
 import {
   getContainer,
   getPostgresConnectionString,
-} from '@opengovsg/starter-kitty-testcontainers'
+} from '@opengovsg/testcontainers'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { vi } from 'vitest'
 

--- a/apps/web/tests/e2e/setup/db-setup.ts
+++ b/apps/web/tests/e2e/setup/db-setup.ts
@@ -9,7 +9,7 @@ import {
   getPostgresConnectionString,
   postgres,
   setup,
-} from '@opengovsg/starter-kitty-testcontainers'
+} from '@opengovsg/testcontainers'
 import { PrismaPg } from '@prisma/adapter-pg'
 
 import { PrismaClient } from '@acme/db/client'

--- a/apps/web/tests/e2e/setup/redis-setup.ts
+++ b/apps/web/tests/e2e/setup/redis-setup.ts
@@ -4,7 +4,7 @@
  * This file sets up a Redis container for E2E tests using Testcontainers.
  * It provides utilities to start the container and flush data between tests.
  */
-import { redis, setup } from '@opengovsg/starter-kitty-testcontainers'
+import { redis, setup } from '@opengovsg/testcontainers'
 
 type RedisContainer = Awaited<ReturnType<typeof startRedis>>
 

--- a/apps/web/tests/global-setup.ts
+++ b/apps/web/tests/global-setup.ts
@@ -1,5 +1,5 @@
-import { postgres, redis } from '@opengovsg/starter-kitty-testcontainers'
-import { createGlobalSetup } from '@opengovsg/starter-kitty-testcontainers/vitest'
+import { postgres, redis } from '@opengovsg/testcontainers'
+import { createGlobalSetup } from '@opengovsg/testcontainers/vitest'
 
 // Redis is shared across parallel workers, so start it with more logical DBs
 // than any plausible worker count (default is 16); each worker selects its own

--- a/apps/web/tests/redis/setup.ts
+++ b/apps/web/tests/redis/setup.ts
@@ -5,11 +5,8 @@
  * It mocks the Redis client to use the test Redis instance.
  */
 
-import {
-  getContainer,
-  getRedisUrl,
-} from '@opengovsg/starter-kitty-testcontainers'
-import { getWorkerDatabaseIndex } from '@opengovsg/starter-kitty-testcontainers/vitest'
+import { getContainer, getRedisUrl } from '@opengovsg/testcontainers'
+import { getWorkerDatabaseIndex } from '@opengovsg/testcontainers/vitest'
 
 import { Redis } from '@acme/redis/testing'
 

--- a/apps/web/tests/redis/setup.ts
+++ b/apps/web/tests/redis/setup.ts
@@ -5,15 +5,20 @@
  * It mocks the Redis client to use the test Redis instance.
  */
 
-import { getContainer, getRedisUrl } from '@opengovsg/testcontainers'
+import { getRedisUrl } from '@opengovsg/testcontainers'
 import { getWorkerDatabaseIndex } from '@opengovsg/testcontainers/vitest'
+import { inject } from 'vitest'
 
 import { Redis } from '@acme/redis/testing'
 
 // Keep in sync with `redis({ databases })` in global-setup.ts.
 const REDIS_DATABASES = 256
 
-const redisUrl = getRedisUrl(getContainer('redis'))
+const { redis: redisContainer } = inject('testcontainers')
+if (!redisContainer) {
+  throw new Error('redis container not provided by global-setup.ts')
+}
+const redisUrl = getRedisUrl(redisContainer)
 
 export const redis = new Redis(redisUrl)
 

--- a/apps/web/tests/trpc.ts
+++ b/apps/web/tests/trpc.ts
@@ -8,7 +8,6 @@ import type { SessionData } from '~/server/session'
 
 const testLogger = createBaseLogger({
   path: 'tests',
-  traceId: null,
   clientIp: null,
   userAgent: null,
 })

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@opengovsg/starter-kitty-logging": "catalog:",
+    "@opengovsg/logging": "catalog:",
     "@t3-oss/env-core": "catalog:t3-env",
     "dd-trace": "catalog:",
     "zod": "catalog:"

--- a/packages/logging/src/__tests__/index.spec.ts
+++ b/packages/logging/src/__tests__/index.spec.ts
@@ -6,7 +6,6 @@ describe('createBaseLogger', () => {
   it('builds a request-scoped logger that logs, scopes, and audits', () => {
     const logger = createBaseLogger({
       path: 'test',
-      traceId: null,
       clientIp: null,
       userAgent: null,
     })

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -1,5 +1,5 @@
-import { createLogging } from '@opengovsg/starter-kitty-logging'
-import type { Logger } from '@opengovsg/starter-kitty-logging'
+import { createLogging } from '@opengovsg/logging'
+import type { Logger } from '@opengovsg/logging'
 
 import { env } from './env'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,9 @@ catalogs:
     '@hookform/resolvers':
       specifier: ^5.2.2
       version: 5.2.2
-    '@opengovsg/starter-kitty-logging':
-      specifier: ^0.4.0
-      version: 0.4.0
+    '@opengovsg/logging':
+      specifier: ^0.5.1
+      version: 0.5.1
     '@types/node':
       specifier: ^24.10.4
       version: 24.10.4
@@ -301,9 +301,9 @@ importers:
       '@acme/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/typescript
-      '@opengovsg/starter-kitty-testcontainers':
-        specifier: ^0.1.0
-        version: 0.1.0(testcontainers@12.0.1)(zod@4.4.3)
+      '@opengovsg/testcontainers':
+        specifier: ^0.2.0
+        version: 0.2.0(testcontainers@12.0.1)(vitest@4.1.8)(zod@4.4.3)
       '@playwright/test':
         specifier: catalog:playwright
         version: 1.57.0
@@ -489,9 +489,9 @@ importers:
 
   packages/logging:
     dependencies:
-      '@opengovsg/starter-kitty-logging':
+      '@opengovsg/logging':
         specifier: 'catalog:'
-        version: 0.4.0
+        version: 0.5.1
       '@t3-oss/env-core':
         specifier: catalog:t3-env
         version: 0.13.8(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
@@ -1668,6 +1668,9 @@ packages:
     peerDependencies:
       '@openfeature/core': ^1.7.0
 
+  '@opengovsg/logging@0.5.1':
+    resolution: {integrity: sha512-Z1tdztNGBZy3yV49C613yhUwZMOunf+txrqozNKYyLqZRBQOphiPrZPJekrQ6I27j6Kvs+JuHjOiNDzxrcUSrw==}
+
   '@opengovsg/oui-theme@0.0.52':
     resolution: {integrity: sha512-F79f+uCbLZgnLuMphWpgVkrc49NTO8wKB7jk26vsx++3qCTXiI1ytVb/WdikKHIyhT39mFUB/NBd/zdmbXIe4w==}
     peerDependencies:
@@ -1683,14 +1686,15 @@ packages:
       react: '>= 18'
       react-aria-components: ^1.14.0
 
-  '@opengovsg/starter-kitty-logging@0.4.0':
-    resolution: {integrity: sha512-/FH+vLV78LNgpdxfU3Jxb15cj3ZeNM2K6wfchprkMqEPJBqCmYTMjcE7fUfewY1z96UcwcTLQ8ak1KifD5cGEg==}
-
-  '@opengovsg/starter-kitty-testcontainers@0.1.0':
-    resolution: {integrity: sha512-MHH97iw/bVqhfn11zRDDcU0AXHcAlqu5D+Hn1aE8v34cDlB+jTAz8Ke2EAk95QqzT4rTEO3RP1xy/Qi8XKFGlQ==}
+  '@opengovsg/testcontainers@0.2.0':
+    resolution: {integrity: sha512-FhX5CTZAACL8XDDJuvioPKBTgu/C+N7p9/a2wbztFT9QH9X05H6c82zi7NWoEibbVS0BD/lZMVRRCEZ1lzy5Pg==}
     peerDependencies:
       testcontainers: ^10.0.0 || ^11.0.0 || ^12.0.0
+      vitest: ^4.1.0
       zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      vitest:
+        optional: true
 
   '@opentelemetry/api-logs@0.208.0':
     resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
@@ -7966,6 +7970,11 @@ snapshots:
       '@openfeature/core': 1.9.1
     optional: true
 
+  '@opengovsg/logging@0.5.1':
+    dependencies:
+      pino: 10.1.0
+      pino-pretty: 13.1.3
+
   '@opengovsg/oui-theme@0.0.52(react@19.2.7)(tailwind-variants@3.1.1(tailwind-merge@3.4.0)(tailwindcss@4.3.3))(tailwindcss@4.3.3)':
     dependencies:
       clsx: 2.1.1
@@ -8013,15 +8022,12 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@opengovsg/starter-kitty-logging@0.4.0':
-    dependencies:
-      pino: 10.1.0
-      pino-pretty: 13.1.3
-
-  '@opengovsg/starter-kitty-testcontainers@0.1.0(testcontainers@12.0.1)(zod@4.4.3)':
+  '@opengovsg/testcontainers@0.2.0(testcontainers@12.0.1)(vitest@4.1.8)(zod@4.4.3)':
     dependencies:
       testcontainers: 12.0.1
       zod: 4.4.3
+    optionalDependencies:
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.12.7(@types/node@24.10.4)(typescript@5.9.3))(vite@8.1.3(@types/node@24.10.4)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.9.0))
 
   '@opentelemetry/api-logs@0.208.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 
 catalog:
   '@hookform/resolvers': ^5.2.2
-  '@opengovsg/starter-kitty-logging': ^0.4.0
+  '@opengovsg/logging': ^0.5.1
   '@types/node': ^24.10.4
   'oxlint': ^1.64.0
   'oxlint-tsgolint': ^0.22.1


### PR DESCRIPTION
## Summary
- Switch to the renamed `@opengovsg/testcontainers` (was `@opengovsg/starter-kitty-testcontainers`) and `@opengovsg/logging` (was `@opengovsg/starter-kitty-logging`), bumped to `^0.2.0` and `catalog:` (`0.5.1`) respectively.
- `@opengovsg/testcontainers` 0.2.0 removes `getContainer` in favor of typed `provide`/`inject` Vitest context; migrated `tests/db/setup.ts` and `tests/redis/setup.ts` to read container info via `inject('testcontainers')`.
- `@opengovsg/logging` 0.5.0 makes `traceId` optional on request loggers in favor of dd-trace log injection; dropped the now-unneeded `traceId` arguments from logger construction call sites.
- Reviewed the current audit event usage (`authn`, `userManagement`) against the full audit spec the logging package ships (`dataAccess`, `configChange`, `apiUsage`, `failures`, `resource`) - existing call sites already match the spec correctly, and the other categories have no corresponding functionality in this starter kit yet, so no new audit calls were added.

## Test plan
- [x] `pnpm --filter @acme/logging test` passes
- [x] `pnpm --filter @acme/web lint` passes
- [x] `pnpm --filter @acme/web exec tsc --noEmit` passes
- [x] `pnpm vitest run tests` in `apps/web` passes (53/53, real Postgres/Redis testcontainers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)