### PR TITLE
fix: remove invalid ssr:false dynamic import in error card

### DIFF
--- a/apps/web/src/app/_components/errors/error-card.tsx
+++ b/apps/web/src/app/_components/errors/error-card.tsx
@@ -1,14 +1,8 @@
-import dynamic from 'next/dynamic'
-
 import { cn } from '@opengovsg/oui-theme'
 
 import { ErrorSvg } from '@acme/ui/svgs'
 
-const GoBackButton = dynamic(
-  () =>
-    import('./go-back-button').then((mod) => ({ default: mod.GoBackButton })),
-  { ssr: false }
-)
+import { GoBackButton } from './go-back-button'
 
 interface ErrorCardProps {
   fullscreen?: boolean

--- a/apps/web/src/app/_components/errors/error-card.tsx
+++ b/apps/web/src/app/_components/errors/error-card.tsx
@@ -1,8 +1,8 @@
 import { cn } from '@opengovsg/oui-theme'
 
-import { ErrorSvg } from '@acme/ui/svgs'
-
 import { GoBackButton } from './go-back-button'
+
+import { ErrorSvg } from '@acme/ui/svgs'
 
 interface ErrorCardProps {
   fullscreen?: boolean

--- a/apps/web/src/app/_components/errors/go-back-button.tsx
+++ b/apps/web/src/app/_components/errors/go-back-button.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+
 import { useRouter } from 'next/navigation'
 
 import { Button } from '@opengovsg/oui'

--- a/apps/web/src/app/_components/errors/go-back-button.tsx
+++ b/apps/web/src/app/_components/errors/go-back-button.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 
 import { Button } from '@opengovsg/oui'
@@ -7,8 +8,12 @@ import { Button } from '@opengovsg/oui'
 export const GoBackButton = () => {
   const router = useRouter()
 
-  // window.history.length is always >= 1 (current entry); > 1 means there's a previous entry
-  const canGoBack = window.history.length > 1
+  const [canGoBack, setCanGoBack] = useState(false)
+
+  useEffect(() => {
+    // window.history.length is always >= 1 (current entry); > 1 means there's a previous entry
+    setCanGoBack(window.history.length > 1)
+  }, [])
 
   if (!canGoBack) return null
 


### PR DESCRIPTION
## Summary
- `ErrorCard` is a Server Component that wrapped `GoBackButton` in `next/dynamic(..., { ssr: false })`, which Next.js disallows in Server Components ("`ssr: false` is not allowed with `next/dynamic` in Server Components").
- `GoBackButton` is already marked `'use client'`, so the dynamic/no-SSR wrapper served no purpose — importing it directly fixes the error.

## Test plan
- [x] Reproduced the build/runtime error locally on a page rendering `ErrorCard`
- [x] Confirmed the error is gone after switching to a direct import
- [ ] Verify `GoBackButton` still renders/hides correctly based on browser history