### PR TITLE
fix: Enhance action.yml with job-index input

### DIFF
--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -20,8 +20,8 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo
-        # inputs.job-index disambiguates matrix legs sharing the same github.job (e.g. test-studio's
-        # shards), which would otherwise race to reserve the same cache key. Defaults to 0 on non-matrix
+        # inputs.job-index disambiguates matrix legs sharing the same github.job (e.g. concurrent vitest shards),
+        # which would otherwise race to reserve the same cache key. Defaults to 0 on non-matrix
         # jobs, so the key there is unaffected.
         key: ${{ runner.os }}-turbo-${{ github.job }}-${{ inputs.job-index }}-${{ github.sha }}
         restore-keys: |

--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -1,6 +1,12 @@
 name: 'Setup and install'
 description: 'Common setup steps for Actions'
 
+inputs:
+  job-index:
+    description: "Index of the current job within its matrix, if any. Composite actions can't read the caller's strategy context directly, so matrixed callers must pass it in explicitly to disambiguate their turbo cache key."
+    required: false
+    default: "0"
+
 runs:
   using: composite
   steps:
@@ -14,10 +20,12 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo
-        # strategy.job-index prevents matrix jobs (e.g. concurrent vitest shards) sharing the same job name from clashing over one cache entry
-        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}
+        # inputs.job-index disambiguates matrix legs sharing the same github.job (e.g. test-studio's
+        # shards), which would otherwise race to reserve the same cache key. Defaults to 0 on non-matrix
+        # jobs, so the key there is unaffected.
+        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ inputs.job-index }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-
+          ${{ runner.os }}-turbo-${{ github.job }}-${{ inputs.job-index }}-
 
     - shell: bash
       run: pnpm install


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

we are using this action.yml as a composite action and not a workflow directly, so we would not be able to utilise the strategy context correctly (strategy.job-index will always be 0). We should pass in this job index as an input from the calling workflow

## Solution

_How did you solve the problem?_

**Bug Fixes**:

- Added 'job-index' input to disambiguate cache keys for matrix jobs.

