### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/dev.sh
+++ b/.cursor/dev.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Long-running Next.js dev server (Turborepo watch mode). Runs as a Cloud Agent
+# terminal so its logs stay visible. Uses stream output rather than the Turbo
+# TUI so logs render cleanly in a non-attached terminal.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+[ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
+nvm use >/dev/null 2>&1 || nvm use 24.13.0 >/dev/null 2>&1 || true
+corepack enable >/dev/null 2>&1 || true
+
+export TURBO_UI=false
+exec corepack pnpm dev

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,12 @@
+{
+  "name": "OGP Starter Kit",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "web-dev",
+      "command": "bash .cursor/dev.sh"
+    }
+  ],
+  "ports": [3000]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Cloud Agent install phase: prepare durable, source-derived state for the
+# Starter Kit monorepo. Runs after the repository is checked out. Must be
+# idempotent and must terminate (no long-running processes here).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Use the Node version pinned by the repo (.nvmrc / package.json engines).
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+[ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
+nvm use >/dev/null 2>&1 || nvm use 24.13.0 >/dev/null 2>&1 || true
+corepack enable >/dev/null 2>&1 || true
+
+echo "[install] node $(node -v) / pnpm $(corepack pnpm -v)"
+
+# Create the local .env from the committed template on first run. SESSION_SECRET
+# must be >= 32 chars (validated by apps/web/src/env.ts); generate a random one.
+if [ ! -f .env ]; then
+  echo "[install] Creating .env from .env.example"
+  SECRET="$(node -e "console.log(require('crypto').randomUUID()+require('crypto').randomUUID())")"
+  sed "s|SESSION_SECRET='please-generate-a-secret-and-put-it-here'|SESSION_SECRET='${SECRET}'|" \
+    .env.example >.env
+fi
+
+echo "[install] Installing workspace dependencies"
+corepack pnpm install --frozen-lockfile
+
+# Generate the Prisma client + Kysely types. This is source-derived and needs
+# no database connection, so it belongs in install (not start).
+echo "[install] Generating Prisma client"
+corepack pnpm -F @acme/db generate
+
+echo "[install] Done"

--- a/.cursor/services.sh
+++ b/.cursor/services.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Bring up the local infrastructure the Starter Kit expects (PostgreSQL + Redis)
+# on the ports declared in docker-compose.yml / .env.example, without Docker.
+#
+# This script is idempotent: it initialises data directories on first run and
+# is safe to invoke on every boot. It waits until each service is accepting
+# connections before returning so callers can rely on the services being ready.
+set -euo pipefail
+
+PG_BIN="/usr/lib/postgresql/16/bin"
+STATE_DIR="${HOME}/.local/share/starter-kit"
+PGDATA="${STATE_DIR}/pgdata"
+PGLOG="${STATE_DIR}/postgres.log"
+REDIS_DIR="${STATE_DIR}/redis"
+REDIS_LOG="${STATE_DIR}/redis.log"
+
+PG_PORT=54321
+PG_USER=root
+PG_PASSWORD=root
+PG_DB=app
+
+REDIS_PORT=63791
+
+mkdir -p "${STATE_DIR}" "${REDIS_DIR}"
+
+# ---------------------------------------------------------------------------
+# Docker daemon (best-effort)
+#
+# The app itself runs against the native PostgreSQL/Redis started below, but the
+# `apps/web` Vitest suite uses testcontainers, which needs a Docker daemon. This
+# VM has no systemd, so start dockerd manually with the fuse-overlayfs storage
+# driver. Failure here is non-fatal: the app and native services still work.
+# ---------------------------------------------------------------------------
+if command -v dockerd >/dev/null 2>&1; then
+  if ! sudo docker info >/dev/null 2>&1; then
+    echo "[services] Starting Docker daemon (for testcontainers)"
+    sudo mkdir -p /etc/docker
+    echo '{"storage-driver":"fuse-overlayfs"}' | sudo tee /etc/docker/daemon.json >/dev/null
+    sudo bash -c 'nohup dockerd >/var/log/dockerd.log 2>&1 &'
+    for _ in $(seq 1 30); do
+      if sudo docker info >/dev/null 2>&1; then break; fi
+      sleep 1
+    done
+  fi
+  # Let the non-root dev user reach the daemon without sudo.
+  if [ -S /var/run/docker.sock ]; then
+    sudo chmod 666 /var/run/docker.sock || true
+  fi
+  if sudo docker info >/dev/null 2>&1; then
+    echo "[services] Docker daemon is ready"
+  else
+    echo "[services] WARN: Docker daemon not available; testcontainers tests will be skipped"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# PostgreSQL
+# ---------------------------------------------------------------------------
+if [ ! -s "${PGDATA}/PG_VERSION" ]; then
+  echo "[services] Initialising PostgreSQL data directory at ${PGDATA}"
+  install -d -m 700 "${PGDATA}"
+  PWFILE="$(mktemp)"
+  printf '%s' "${PG_PASSWORD}" >"${PWFILE}"
+  "${PG_BIN}/initdb" \
+    --username="${PG_USER}" \
+    --pwfile="${PWFILE}" \
+    --auth-local=trust \
+    --auth-host=md5 \
+    --encoding=UTF8 \
+    -D "${PGDATA}" >/dev/null
+  rm -f "${PWFILE}"
+fi
+
+if ! "${PG_BIN}/pg_ctl" -D "${PGDATA}" status >/dev/null 2>&1; then
+  echo "[services] Starting PostgreSQL on port ${PG_PORT}"
+  "${PG_BIN}/pg_ctl" -D "${PGDATA}" -l "${PGLOG}" \
+    -o "-p ${PG_PORT} -c listen_addresses=localhost -c unix_socket_directories=${STATE_DIR}" \
+    -w start
+else
+  echo "[services] PostgreSQL already running"
+fi
+
+# Wait until PostgreSQL is ready to accept connections.
+for _ in $(seq 1 30); do
+  if "${PG_BIN}/pg_isready" -h localhost -p "${PG_PORT}" -U "${PG_USER}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+# Ensure the application database exists (initdb only created the role's own db).
+# Use PGPASSWORD so non-interactive md5 auth over TCP does not block on a prompt.
+export PGPASSWORD="${PG_PASSWORD}"
+if ! "${PG_BIN}/psql" -h localhost -p "${PG_PORT}" -U "${PG_USER}" -d postgres \
+  -tAc "SELECT 1 FROM pg_database WHERE datname='${PG_DB}'" | grep -q 1; then
+  echo "[services] Creating database '${PG_DB}'"
+  "${PG_BIN}/createdb" -h localhost -p "${PG_PORT}" -U "${PG_USER}" "${PG_DB}"
+fi
+
+# ---------------------------------------------------------------------------
+# Redis
+# ---------------------------------------------------------------------------
+if ! redis-cli -p "${REDIS_PORT}" ping >/dev/null 2>&1; then
+  echo "[services] Starting Redis on port ${REDIS_PORT}"
+  redis-server \
+    --port "${REDIS_PORT}" \
+    --daemonize yes \
+    --dir "${REDIS_DIR}" \
+    --logfile "${REDIS_LOG}" \
+    --save "" \
+    --appendonly no
+  for _ in $(seq 1 30); do
+    if redis-cli -p "${REDIS_PORT}" ping >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+else
+  echo "[services] Redis already running"
+fi
+
+echo "[services] PostgreSQL and Redis are ready"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Cloud Agent start phase: per-boot reconciliation. Brings up PostgreSQL and
+# Redis and syncs the Prisma schema to the database. Idempotent and returns
+# once the environment is ready (the dev server itself runs as a terminal).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+[ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
+nvm use >/dev/null 2>&1 || nvm use 24.13.0 >/dev/null 2>&1 || true
+corepack enable >/dev/null 2>&1 || true
+
+# Start PostgreSQL + Redis on the ports the app expects (see .env.example).
+bash .cursor/services.sh
+
+# Apply the Prisma schema to the database. `prisma db push` is idempotent and
+# fast; running it on boot guarantees the schema exists even on a fresh volume.
+# Invoke the package script directly rather than `pnpm db:push`, whose Turbo task
+# is flagged interactive (TUI) and cannot run in a non-interactive boot shell.
+echo "[start] Syncing Prisma schema to database"
+corepack pnpm --filter @acme/db push
+
+echo "[start] Environment ready"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,7 +315,7 @@ importers:
         version: 1.57.0
       '@prisma/adapter-pg':
         specifier: catalog:prisma
-        version: 7.9.0
+        version: 7.9.1
       '@storybook/addon-a11y':
         specifier: catalog:storybook10
         version: 10.5.0(storybook@10.5.0(@types/react@19.2.17)(react@19.2.8))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up a repository-managed Cloud Agent development environment for the Starter Kit monorepo so agents can install, run, and test the app end to end. Because `.cursor/environment.json` is committed, it is the highest-precedence environment source and takes effect for agents once this branch is checked out / merged.

### Environment config (`.cursor/`)
- `environment.json` — declares `install`, `start`, a `web-dev` terminal, and exposes port `3000`.
- `install.sh` — pins Node 24 (nvm) + pnpm 11.20.0, creates `.env` from `.env.example` with a generated `SESSION_SECRET`, runs `pnpm install --frozen-lockfile`, and generates the Prisma client.
- `services.sh` — starts native PostgreSQL (`54321`) and Redis (`63791`) on the ports `.env.example` expects (Docker isn't required for the app itself), and best-effort starts a Docker daemon (`fuse-overlayfs`) so the `apps/web` testcontainers Vitest suite runs.
- `start.sh` — brings up services and syncs the Prisma schema (`prisma db push`).
- `dev.sh` — runs the Next.js dev server (Turborepo watch) as a terminal.

### Lockfile fix
- `pnpm-lock.yaml`: the `apps/web` importer pinned `@prisma/adapter-pg@7.9.0` while the prisma catalog and package snapshot are `7.9.1`, so the lockfile had no entry for `7.9.0`. This breaks `pnpm install --frozen-lockfile` and is currently failing `main` CI. Aligned the importer to the catalog value already used by `packages/db`.

## Why

Docker isn't available by default in the Cloud Agent VM, so PostgreSQL and Redis run natively on the docker-compose ports, keeping `.env.example` working unchanged. Docker is still installed and started best-effort so the testcontainers integration tests run.

## Validation

All commands run with Node 24.13.0 / pnpm 11.20.0.

| Check | Result |
| --- | --- |
| `pnpm lint` + `pnpm lint:ws` | Passed (1 pre-existing warning) |
| `pnpm typecheck` | Passed |
| `pnpm test:ci` | 55 tests passed (incl. testcontainers) |
| `pnpm build` | Passed |
| `GET /api/health` | `{"database":"up"}` |
| Install idempotence | Passed (frozen install twice) |
| OTP login (creates User row) | Passed end-to-end in browser |
| Draft environment build | SUCCEEDED (`bld-20260813-dd5c5251-5376-48fb-86e3-e6a70d9b1578`) |
| Fresh Cloud Agent from that build | All checks PASS (toolchain, deps, services+schema, lint, typecheck, tests, build, dev health) |

A screen recording of the end-to-end OTP sign-in (email → OTP from server log → authenticated `/admin` page, persisting a `User` row) is attached to the Cloud Agent run artifacts.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-988ddc77-ef63-41ed-9293-c571066db9b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-988ddc77-ef63-41ed-9293-c571066db9b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

