### PR TITLE
chore: migrate to pnpm 12.0.0

### DIFF
--- a/apps/web/scripts/vercel-pnpm-env.sh
+++ b/apps/web/scripts/vercel-pnpm-env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PNPM_HOME="${HOME}/.local/share/pnpm"
+
+if [[ ! -x "${PNPM_HOME}/bin/pnpm" ]]; then
+  curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.0.0 SHELL=bash sh -
+fi
+
+# Vercel prepends a broken npm-package placeholder at
+# $PNPM_HOME/.tools/pnpm/<version>/bin/pnpm. Prefer the standalone binary.
+export PATH="${PNPM_HOME}/bin:$(
+  echo "${PATH}" | tr ':' '\n' | grep -v '/\.tools/pnpm/' | paste -sd:
+)"
+
+if ! pnpm --version >/dev/null 2>&1; then
+  echo "pnpm bootstrap failed (pnpm at $(command -v pnpm || echo missing))" >&2
+  exit 1
+fi

--- a/apps/web/scripts/vercel-pnpm-install.sh
+++ b/apps/web/scripts/vercel-pnpm-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "${repo_root}"
 
 source apps/web/scripts/vercel-pnpm-env.sh

--- a/apps/web/scripts/vercel-pnpm-install.sh
+++ b/apps/web/scripts/vercel-pnpm-install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+source apps/web/scripts/vercel-pnpm-env.sh
+pnpm install --frozen-lockfile

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "bash scripts/vercel-pnpm-install.sh",
-  "buildCommand": "source scripts/vercel-pnpm-env.sh && turbo vercel-build"
+  "buildCommand": "bash -c 'source scripts/vercel-pnpm-env.sh && turbo vercel-build'"
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "turbo vercel-build"
+  "installCommand": "bash scripts/vercel-pnpm-install.sh",
+  "buildCommand": "source scripts/vercel-pnpm-env.sh && turbo vercel-build"
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "engines": {
     "node": ">=24.13.0",
-    "pnpm": ">=11.0.0"
+    "pnpm": ">=12.0.0"
   },
-  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee"
+  "packageManager": "pnpm@12.0.0+sha512.9e2e3dc3911995868dc94b8175c217c27e95408fa03b4a22749778f2b34f773b77cdd3b39ede8171b22fcd53be6a35342e9fac9948a68ef58df6488ce89a7e67"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0
+        version: 12.0.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    resolution: {integrity: sha512-sqeoPfVMIfQhbwzDrKraXY2ynyuWClFqzvfImzAS/yczEru1m5SGvQ9kgFPDvQzJZ9AetedgJeDZC6qYvH8/tQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    resolution: {integrity: sha512-Quc3J6c9cGTy+LDgz1cLVgCNOU9IERuyAlDoEj0DCilKqvo50Jx1GV8k74iwn4J9fFSKkm8JrwNvtTDj3uWnUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    resolution: {integrity: sha512-EVWd3OTmgsMFhXx69b5JxIzoabG9Ma7m4OeTaf0ZKBzMnfYi8u21NDQo92ToMrdYL5dYDDCHsyYIjXzk+d0HhA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    resolution: {integrity: sha512-cXHHW8M4rAPsYNkKZO9WVcpLLK55i9EaIsZPfIqUuY2eopd5LqnFyBge54HCh1GC0yCX8ySn0hYIi+4OyAEoDg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    resolution: {integrity: sha512-UcXwMdFjly0mpddkGigHKTxe27IMv2fUK4IWW/MHmJ3yMguxXmkwNlEI4aE+G1HO2TLo20uNEUWD4ymLe/DaCQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    resolution: {integrity: sha512-6Rsl+zEWMOmus7v7/9J3OE8EMvHyNAfxYmDfmhQG4J0985OuT3G3Ho9NSGHjkBn4aU4bgklWifRhe1HX8dUSyw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    resolution: {integrity: sha512-O5F76A4oVFrpDGdFxEszRIThOSBfjHdH5c006gR+7UTCfiXrukr1XfqPungUI1DXcSR5gb9jBsPQqQZOAoOOxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    resolution: {integrity: sha512-5dKFajIEWJ1ai+KHXFJvskY6vchbunmLwSUV2ywbLymcmJjfY5XJVpgzPCyIoVCMVG0zHorr66+hM8h8b3aRfQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0:
+    resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    optional: true
+
+  pnpm@12.0.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -100,7 +100,7 @@ minimumReleaseAgeExclude:
   # newer than `minimumReleaseAge`. If the patched version is already >24h
   # old, the cooldown lets it through on its own.
 
-# Under pnpm v11, every package with a build script must be listed here as
+# Under pnpm v12, every package with a build script must be listed here as
 # true (run the script) or false (skip it). Leaving one unlisted throws
 # ERR_PNPM_IGNORED_BUILDS and fails install (e.g. in CI).
 allowBuilds:

--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -11,6 +11,10 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      with:
+        # pnpm 12's npm package ships a placeholder bin/pnpm shell script that
+        # fails under /bin/sh. Force the standalone @pnpm/exe binary instead.
+        standalone: true
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: 'package.json'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates the monorepo from **pnpm 11.20.0** to **pnpm 12.0.0** (Rust rewrite, stable on the `next-12` dist-tag).

pnpm 12 is a Rust rewrite of the install engine. Commands, flags, settings, and lockfile format are intentionally compatible with pnpm 11 — this is not a full migration, just a version bump.

## Changes

- **`package.json`**: Bump `packageManager` pin (with `+sha512` integrity hash) and `engines.pnpm` to `>=12.0.0`
- **`pnpm-lock.yaml`**: Add pnpm 12's `packageManagerDependencies` env lockfile document
- **`pnpm-workspace.yaml`**: Update `allowBuilds` comment from v11 → v12
- **`tooling/github/setup/action.yml`**: Force `standalone: true` on `pnpm/action-setup` so CI uses the native `@pnpm/exe` binary
- **`apps/web/vercel.json`**: Route install/build through native pnpm bootstrap scripts
- **`apps/web/scripts/vercel-pnpm-{env,install}.sh`**: Bootstrap standalone pnpm 12 and strip Vercel's broken `.tools/pnpm` shim from `PATH` (fix from [opengovsg/isomer#3251](https://github.com/opengovsg/isomer/pull/3251))

## Benchmark results

(this repo, Linux x86_64, `pnpm install --frozen-lockfile`, median of 3 runs, includes postinstall)

| Scenario | pnpm 11.20.0 | pnpm 12.0.0 | Delta |
|---|---|---|---|
| Cold install | ~4.6s | ~3.5s | ~26% faster |
| Warm install | ~1.3s | ~0.8s | ~34% faster |

## pnpm 12 placeholder binary fix

pnpm 12's npm package ships a placeholder `bin/pnpm` shell script that fails under `/bin/sh` with `syntax error near unexpected token ')'`. This affects:

- **GitHub Actions**: `pnpm/action-setup` defaults to the npm package on Node ≥ 22.13 — fixed with `standalone: true`
- **Vercel**: prepends broken shim at `$PNPM_HOME/.tools/pnpm/12.0.0/bin/pnpm` — fixed with `get.pnpm.io` bootstrap scripts

## pnpm 12 breaking changes reviewed

| Change | Impact on this repo |
|--------|---------------------|
| Unrecognized `pnpm-workspace.yaml` settings now error when pinned | All settings validated — no unrecognized keys |
| `pnpm install --resolution-only` removed | Not used |
| Git deps resolve via canonical HTTPS | No git-hosted deps in lockfile |
| Cyclic dependency lockfile re-keying | Lockfile unchanged aside from packageManager section |
| `engineStrict` follows optional dep edges | No impact observed |
| `filterLog` pnpmfile hook deprecated | Not used |

## Verification

- `pnpm install --frozen-lockfile` — passes
- `pnpm lint:ws` (sherif) — no issues
- `pnpm typecheck` — all 15 tasks pass
- `vercel-pnpm-env.sh` with simulated broken Vercel PATH — bootstraps pnpm 12.0.0 successfully
- `vercel-pnpm-install.sh` from `apps/web` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4409c664-c7ed-4a90-b5a7-ef24df66d4d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4409c664-c7ed-4a90-b5a7-ef24df66d4d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

